### PR TITLE
Enhance output with IAM Role ARN to enable security customization

### DIFF
--- a/modules/lambda/outputs.tf
+++ b/modules/lambda/outputs.tf
@@ -18,6 +18,11 @@ output "role_name" {
   value       = aws_iam_role.lambda.name
 }
 
+output "role_arn" {
+  description = "The arn of the IAM role attached to the Lambda Function. This enables attaching policies after creation for more customization."
+  value       = aws_iam_role.lambda.arn
+}
+
 output "version" {
   description = "Latest published version of your Lambda Function."
   value       = var.ignore_external_function_updates ? aws_lambda_function.lambda_external_lifecycle[0].version : aws_lambda_function.lambda[0].version

--- a/outputs.tf
+++ b/outputs.tf
@@ -23,6 +23,11 @@ output "role_name" {
   value       = module.lambda.role_name
 }
 
+output "role_arn" {
+  description = "The arn of the IAM role attached to the Lambda Function. This enables attaching policies after creation for more customization."
+  value       = module.lambda.role_arn
+}
+
 output "version" {
   description = "Latest published version of your Lambda Function."
   value       = module.lambda.version


### PR DESCRIPTION
With this PR you can add custom policies to the created role. E.g. like this you can enable your lambda to access specific secrets from a secrets manager. Probably it would be better to expose the iam role in total in the output but this would be a breaking change because one would delete the role_name from the output for consistency.