### PR TITLE
Fix unnecessary tf changes in deployment module

### DIFF
--- a/modules/deployment/iam_codebuild.tf
+++ b/modules/deployment/iam_codebuild.tf
@@ -1,103 +1,76 @@
 resource "aws_iam_role" "codebuild_role" {
   count = var.codebuild_role_arn == "" ? 1 : 0
 
-  name               = "${var.function_name}-build-${data.aws_region.current.name}"
-  assume_role_policy = data.aws_iam_policy_document.allow_codebuild_assume[count.index].json
-  tags               = var.tags
-}
+  name = "${var.function_name}-codebuild-${data.aws_region.current.name}"
+  tags = var.tags
 
-data "aws_iam_policy_document" "allow_codebuild_assume" {
-  count = var.codebuild_role_arn == "" ? 1 : 0
-
-  statement {
-    actions = ["sts:AssumeRole"]
-    principals {
-      type        = "Service"
-      identifiers = ["codebuild.amazonaws.com"]
-    }
-  }
-}
-
-resource "aws_iam_policy" "codebuild" {
-  count = var.codebuild_role_arn == "" ? 1 : 0
-
-  name   = "${var.function_name}-build-${data.aws_region.current.name}"
-  policy = data.aws_iam_policy_document.codebuild[count.index].json
-}
-
-resource "aws_iam_role_policy_attachment" "codebuild" {
-  count = var.codebuild_role_arn == "" ? 1 : 0
-
-  role       = aws_iam_role.codebuild_role[count.index].name
-  policy_arn = aws_iam_policy.codebuild[count.index].arn
-}
-
-data "aws_iam_policy_document" "codebuild" {
-  count = var.codebuild_role_arn == "" ? 1 : 0
-
-  statement {
-    actions = [
-      "codedeploy:CreateDeployment"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Sid    = ""
+        Principal = {
+          Service = "codebuild.amazonaws.com"
+        }
+      },
     ]
+  })
 
-    resources = [
-      "arn:aws:codedeploy:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:deploymentgroup:${aws_codedeploy_app.this.name}/${aws_codedeploy_deployment_group.this.deployment_group_name}"
-    ]
-  }
+  inline_policy {
+    name = "${var.function_name}-codebuild-${data.aws_region.current.name}"
 
-  statement {
-    actions = [
-      "codedeploy:GetDeploymentConfig"
-    ]
-
-    resources = [
-      "arn:aws:codedeploy:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:deploymentconfig:${var.deployment_config_name}"
-    ]
-  }
-
-  statement {
-    actions = [
-      "codedeploy:GetApplicationRevision",
-      "codedeploy:RegisterApplicationRevision"
-    ]
-
-    resources = [
-      "arn:aws:codedeploy:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:application:${aws_codedeploy_app.this.name}"
-    ]
-  }
-
-  statement {
-    actions = [
-      "lambda:GetAlias",
-      "lambda:GetFunction",
-      "lambda:GetFunctionConfiguration",
-      "lambda:PublishVersion",
-      "lambda:UpdateFunctionCode"
-    ]
-
-    resources = [
-      "arn:aws:lambda:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:function:${var.function_name}"
-    ]
-  }
-
-  statement {
-    actions = [
-      "logs:CreateLogStream",
-      "logs:CreateLogGroup",
-      "logs:PutLogEvents"
-    ]
-
-    resources = [
-      "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/aws/codebuild/*"
-    ]
-  }
-
-  statement {
-    actions = [
-      "s3:Get*",
-      "s3:PutObject"
-    ]
-
-    resources = ["${module.s3_bucket.this_s3_bucket_arn}/*"]
+    policy = jsonencode({
+      Version = "2012-10-17"
+      Statement = [
+        {
+          Action   = ["codedeploy:CreateDeployment"]
+          Effect   = "Allow"
+          Resource = "arn:aws:codedeploy:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:deploymentgroup:${aws_codedeploy_app.this.name}/${aws_codedeploy_deployment_group.this.deployment_group_name}"
+        },
+        {
+          Action   = ["codedeploy:GetDeploymentConfig"]
+          Effect   = "Allow"
+          Resource = "arn:aws:codedeploy:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:deploymentconfig:${var.deployment_config_name}"
+        },
+        {
+          Action = [
+            "codedeploy:GetApplicationRevision",
+            "codedeploy:RegisterApplicationRevision"
+          ]
+          Effect   = "Allow"
+          Resource = "arn:aws:codedeploy:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:application:${aws_codedeploy_app.this.name}"
+        },
+        {
+          Action = [
+            "lambda:GetAlias",
+            "lambda:GetFunction",
+            "lambda:GetFunctionConfiguration",
+            "lambda:PublishVersion",
+            "lambda:UpdateFunctionCode"
+          ]
+          Effect   = "Allow"
+          Resource = "arn:aws:lambda:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:function:${var.function_name}"
+        },
+        {
+          Action = [
+            "logs:CreateLogStream",
+            "logs:CreateLogGroup",
+            "logs:PutLogEvents"
+          ]
+          Effect   = "Allow"
+          Resource = "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/aws/codebuild/*"
+        },
+        {
+          Action = [
+            "s3:Get*",
+            "s3:PutObject"
+          ]
+          Effect   = "Allow"
+          Resource = "${module.s3_bucket.this_s3_bucket_arn}/*"
+        }
+      ]
+    })
   }
 }

--- a/modules/deployment/iam_codedeploy.tf
+++ b/modules/deployment/iam_codedeploy.tf
@@ -1,19 +1,20 @@
-data "aws_iam_policy_document" "codedeploy" {
-  statement {
-    effect  = "Allow"
-    actions = ["sts:AssumeRole"]
-
-    principals {
-      type        = "Service"
-      identifiers = ["codedeploy.amazonaws.com"]
-    }
-  }
-}
-
 resource "aws_iam_role" "codedeploy" {
-  assume_role_policy = data.aws_iam_policy_document.codedeploy.json
-  name               = "${var.function_name}-deploy-${data.aws_region.current.name}"
-  tags               = var.tags
+  name = "${var.function_name}-codedeploy-${data.aws_region.current.name}"
+  tags = var.tags
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Sid    = ""
+        Principal = {
+          Service = "codedeploy.amazonaws.com"
+        }
+      },
+    ]
+  })
 }
 
 resource "aws_iam_role_policy_attachment" "codedeploy" {

--- a/modules/deployment/iam_codepipeline.tf
+++ b/modules/deployment/iam_codepipeline.tf
@@ -1,67 +1,55 @@
 resource "aws_iam_role" "codepipeline_role" {
   count = var.codepipeline_role_arn == "" ? 1 : 0
 
-  name               = "${var.function_name}-pipeline-${data.aws_region.current.name}"
-  assume_role_policy = data.aws_iam_policy_document.codepipeline[count.index].json
-  tags               = var.tags
-}
+  name = "${var.function_name}-codepipeline-${data.aws_region.current.name}"
+  tags = var.tags
 
-data "aws_iam_policy_document" "codepipeline" {
-  count = var.codepipeline_role_arn == "" ? 1 : 0
-
-  statement {
-    actions = ["sts:AssumeRole"]
-    principals {
-      type        = "Service"
-      identifiers = ["codepipeline.amazonaws.com"]
-    }
-  }
-}
-
-resource "aws_iam_policy" "codepipeline" {
-  count = var.codepipeline_role_arn == "" ? 1 : 0
-
-  name   = "${var.function_name}-pipeline-${data.aws_region.current.name}"
-  policy = data.aws_iam_policy_document.codepipeline_permissions[count.index].json
-}
-
-resource "aws_iam_role_policy_attachment" "codepipepline_extra" {
-  count = var.codepipeline_role_arn == "" ? 1 : 0
-
-  role       = aws_iam_role.codepipeline_role[count.index].name
-  policy_arn = aws_iam_policy.codepipeline[count.index].arn
-}
-
-data "aws_iam_policy_document" "codepipeline_permissions" {
-  count = var.codepipeline_role_arn == "" ? 1 : 0
-
-  statement {
-    actions = ["ecr:DescribeImages"]
-
-    resources = [
-      "arn:aws:ecr:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:repository/${var.ecr_repository_name}"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Sid    = ""
+        Principal = {
+          Service = "codepipeline.amazonaws.com"
+        }
+      },
     ]
-  }
+  })
 
-  statement {
-    actions = [
-      "s3:GetObject",
-      "s3:ListBucket",
-      "s3:PutObject"
-    ]
+  inline_policy {
+    name = "${var.function_name}-codepipeline-${data.aws_region.current.name}"
 
-    resources = [
-      module.s3_bucket.this_s3_bucket_arn,
-      "${module.s3_bucket.this_s3_bucket_arn}/*"
-    ]
-  }
-
-  statement {
-    actions = [
-      "codebuild:StartBuild",
-      "codebuild:BatchGetBuilds"
-    ]
-
-    resources = [aws_codebuild_project.this.arn]
+    policy = jsonencode({
+      Version = "2012-10-17"
+      Statement = [
+        {
+          Action = [
+            "codebuild:StartBuild",
+            "codebuild:BatchGetBuilds"
+          ]
+          Effect   = "Allow"
+          Resource = aws_codebuild_project.this.arn
+        },
+        {
+          Action   = ["ecr:DescribeImages"]
+          Effect   = "Allow"
+          Resource = "arn:aws:ecr:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:repository/${var.ecr_repository_name}"
+        },
+        {
+          Action = [
+            "s3:GetObject",
+            "s3:ListBucket",
+            "s3:PutObject"
+          ]
+          Effect = "Allow"
+          Resource = [
+            module.s3_bucket.this_s3_bucket_arn,
+            "${module.s3_bucket.this_s3_bucket_arn}/*"
+          ]
+        }
+      ]
+    })
   }
 }


### PR DESCRIPTION
When using the deployment module, terraform wants to change resources from that module even if they should not be affected (e.g. when changing properties in the Lambda module). 

Using inline policies seems to solve this problem.