### PR TITLE
Add cloudwatch_log_group_arn output

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,7 @@ MINOR, and PATCH versions on each release to indicate any incompatibilities.
 | Name | Description |
 |------|-------------|
 | <a name="output_arn"></a> [arn](#output\_arn) | The Amazon Resource Name (ARN) identifying your Lambda Function. |
+| <a name="output_cloudwatch_log_group_arn"></a> [cloudwatch\_log\_group\_arn](#output\_cloudwatch\_log\_group\_arn) | The Amazon Resource Name (ARN) identifying the CloudWatch log group used by your Lambda function. |
 | <a name="output_cloudwatch_log_group_name"></a> [cloudwatch\_log\_group\_name](#output\_cloudwatch\_log\_group\_name) | The name of the CloudWatch log group used by your Lambda function. |
 | <a name="output_function_name"></a> [function\_name](#output\_function\_name) | The unique name of your Lambda Function. |
 | <a name="output_invoke_arn"></a> [invoke\_arn](#output\_invoke\_arn) | The ARN to be used for invoking Lambda Function from API Gateway - to be used in aws\_api\_gateway\_integration's uri |

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,6 +8,11 @@ output "cloudwatch_log_group_name" {
   value       = aws_cloudwatch_log_group.lambda.name
 }
 
+output "cloudwatch_log_group_arn" {
+  description = "The Amazon Resource Name (ARN) identifying the CloudWatch log group used by your Lambda function."
+  value       = aws_cloudwatch_log_group.lambda.arn
+}
+
 output "function_name" {
   description = "The unique name of your Lambda Function."
   value       = module.lambda.function_name


### PR DESCRIPTION
This is useful for creating IAM policies with read access to that Cloudwatch Log group.

Optionally one could just expose the whole log group resource instead of exposing of select properties.