### PR TITLE
deployment: use external/existing s3 bucket

### DIFF
--- a/modules/deployment/iam_codebuild.tf
+++ b/modules/deployment/iam_codebuild.tf
@@ -68,7 +68,7 @@ resource "aws_iam_role" "codebuild_role" {
             "s3:PutObject"
           ]
           Effect   = "Allow"
-          Resource = "${aws_s3_bucket.pipeline.arn}/*"
+          Resource = "${data.aws_s3_bucket.artefacts.arn}/*"
         }
       ]
     })

--- a/modules/deployment/iam_codepipeline.tf
+++ b/modules/deployment/iam_codepipeline.tf
@@ -19,30 +19,6 @@ resource "aws_iam_role" "codepipeline_role" {
   })
 
   dynamic "inline_policy" {
-    for_each = var.s3_bucket != "" ? [true] : []
-    content {
-      name = "${var.function_name}-codepipeline-s3-${data.aws_region.current.name}"
-
-      policy = jsonencode({
-        Version = "2012-10-17"
-        Statement = [
-          {
-            Action = [
-              "s3:Get*",
-              "s3:ListBucket"
-            ]
-            Effect = "Allow"
-            Resource = [
-              "arn:aws:s3:::${var.s3_bucket}",
-              "arn:aws:s3:::${var.s3_bucket}/*",
-            ]
-          }
-        ]
-      })
-    }
-  }
-
-  dynamic "inline_policy" {
     for_each = var.ecr_repository_name != "" ? [true] : []
     content {
       name = "${var.function_name}-codepipeline-ecr-${data.aws_region.current.name}"
@@ -76,14 +52,14 @@ resource "aws_iam_role" "codepipeline_role" {
         },
         {
           Action = [
-            "s3:GetObject",
-            "s3:ListBucket",
-            "s3:PutObject"
+            "s3:Get*",
+            "s3:PutObject*",
+            "s3:ListBucket"
           ]
           Effect = "Allow"
           Resource = [
-            aws_s3_bucket.pipeline.arn,
-            "${aws_s3_bucket.pipeline.arn}/*"
+            data.aws_s3_bucket.artefacts.arn,
+            "${data.aws_s3_bucket.artefacts.arn}/${substr(var.function_name, 0, 21)}/*"
           ]
         }
       ]

--- a/modules/deployment/main.tf
+++ b/modules/deployment/main.tf
@@ -1,5 +1,8 @@
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
+data "aws_s3_bucket" "artefacts" {
+  bucket = var.s3_bucket
+}
 
 resource "aws_codepipeline" "this" {
   name     = var.function_name
@@ -7,7 +10,7 @@ resource "aws_codepipeline" "this" {
   tags     = var.tags
 
   artifact_store {
-    location = aws_s3_bucket.pipeline.bucket
+    location = var.s3_bucket
     type     = "S3"
   }
 
@@ -83,20 +86,4 @@ resource "aws_codepipeline" "this" {
       }
     }
   }
-}
-
-resource "aws_s3_bucket" "pipeline" {
-  acl           = "private"
-  bucket        = "${var.function_name}-pipeline-${data.aws_caller_identity.current.account_id}-${data.aws_region.current.name}"
-  force_destroy = true
-  tags          = var.tags
-}
-
-resource "aws_s3_bucket_public_access_block" "source" {
-  bucket = aws_s3_bucket.pipeline.id
-
-  block_public_acls       = true
-  block_public_policy     = true
-  ignore_public_acls      = true
-  restrict_public_buckets = true
 }

--- a/modules/deployment/variables.tf
+++ b/modules/deployment/variables.tf
@@ -103,8 +103,7 @@ variable "ecr_repository_name" {
 }
 
 variable "s3_bucket" {
-  description = "Name of the bucket used for S3 based deployments, required for `package_type=Zip`."
-  default     = ""
+  description = "Name of the bucket used for S3 based deployments, this bucket will also used for pipeline artefacts. A folder to contain the pipeline artifacts is created for you based on the name of the pipeline."
   type        = string
 }
 


### PR DESCRIPTION
- do not create s3 buckets within this module
- use the `var.s3_bucket` [now mandatory] as s3-source && codepipeline storage
- adapted permissions (`s3:PutObject*`) to also allow s3 buckets with versioning enabled