### PR TITLE
fix(IAM): Add kinesis:ListShards IAM permission

### DIFF
--- a/event_source_mappings.tf
+++ b/event_source_mappings.tf
@@ -115,7 +115,8 @@ data "aws_iam_policy_document" "event_sources" {
         "kinesis:DescribeStream",
         "kinesis:DescribeStreamSummary",
         "kinesis:GetRecords",
-        "kinesis:GetShardIterator"
+        "kinesis:GetShardIterator",
+        "kinesis:ListShards"
       ]
 
       resources = [


### PR DESCRIPTION
>This API is a new operation that is used by the Amazon Kinesis Client Library (KCL). If you have a fine-grained IAM policy that only allows specific operations, you must update your policy to allow calls to this API. For more information, see [Controlling Access to Amazon Kinesis Data Streams Resources Using IAM](https://docs.aws.amazon.com/streams/latest/dev/controlling-access.html).

From https://docs.aws.amazon.com/kinesis/latest/APIReference/API_ListShards.html