### PR TITLE
feat: add input argument for cloudwatch_event_target

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ module "lambda" {
 
       // optionally overwrite `cloudwatch_event_target_arn` in case an alias should be used for the event rule
       cloudwatch_event_target_arn = aws_lambda_alias.example.arn
+      
       // optionally add `cloudwatch_event_target_input` for event input
       cloudwatch_event_target_input = jsonencode({"key": "value"})
     }

--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ module "lambda" {
 
       // optionally overwrite `cloudwatch_event_target_arn` in case an alias should be used for the event rule
       cloudwatch_event_target_arn = aws_lambda_alias.example.arn
+      // optionally add `cloudwatch_event_target_input` for event input
+      cloudwatch_event_target_input = jsonencode({"key": "value"})
     }
 
     pattern = {

--- a/cloudwatch_event_rules.tf
+++ b/cloudwatch_event_rules.tf
@@ -25,6 +25,7 @@ resource "aws_cloudwatch_event_rule" "lambda" {
 resource "aws_cloudwatch_event_target" "lambda" {
   for_each = var.cloudwatch_event_rules
 
-  arn  = lookup(each.value, "cloudwatch_event_target_arn", local.function_arn)
-  rule = aws_cloudwatch_event_rule.lambda[each.key].name
+  arn   = lookup(each.value, "cloudwatch_event_target_arn", local.function_arn)
+  rule  = aws_cloudwatch_event_rule.lambda[each.key].name
+  input = lookup(each.value, "cloudwatch_event_target_input", null)
 }

--- a/docs/deployment/part2.md
+++ b/docs/deployment/part2.md
@@ -9,7 +9,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.9 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.67.0 |
 
 ## Modules
 

--- a/docs/deployment/part2.md
+++ b/docs/deployment/part2.md
@@ -9,7 +9,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.67.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.9 |
 
 ## Modules
 

--- a/docs/deployment/part2.md
+++ b/docs/deployment/part2.md
@@ -9,7 +9,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.67.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.9 |
 
 ## Modules
 
@@ -36,6 +36,7 @@ No modules.
 | [aws_iam_role.trigger](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.codedeploy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_s3_bucket.pipeline](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_acl.pipeline](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_acl) | resource |
 | [aws_s3_bucket_policy.cloudtrail](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [aws_s3_bucket_public_access_block.source](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
 | [aws_sns_topic.notifications](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic) | resource |

--- a/docs/part1.md
+++ b/docs/part1.md
@@ -92,6 +92,9 @@ module "lambda" {
 
       // optionally overwrite `cloudwatch_event_target_arn` in case an alias should be used for the event rule
       cloudwatch_event_target_arn = aws_lambda_alias.example.arn
+      
+      // optionally add `cloudwatch_event_target_input` for event input
+      cloudwatch_event_target_input = jsonencode({"key": "value"})
     }
 
     pattern = {

--- a/examples/with-cloudwatch-event-rules/main.tf
+++ b/examples/with-cloudwatch-event-rules/main.tf
@@ -29,7 +29,7 @@ module "lambda" {
       cloudwatch_event_target_arn = aws_lambda_alias.example.arn
 
       // optionally add `cloudwatch_event_target_input` for event input
-      cloudwatch_event_target_input = jsonencode({"key": "value"})
+      cloudwatch_event_target_input = jsonencode({ "key" : "value" })
     }
 
     pattern = {

--- a/examples/with-cloudwatch-event-rules/main.tf
+++ b/examples/with-cloudwatch-event-rules/main.tf
@@ -27,6 +27,9 @@ module "lambda" {
 
       // optionally overwrite `cloudwatch_event_target_arn` in case an alias should be used for the event rule
       cloudwatch_event_target_arn = aws_lambda_alias.example.arn
+
+      // optionally add `cloudwatch_event_target_input` for event input
+      cloudwatch_event_target_input = jsonencode({"key": "value"})
     }
 
     pattern = {

--- a/modules/deployment/README.md
+++ b/modules/deployment/README.md
@@ -173,7 +173,7 @@ resource "aws_s3_bucket_object" "source" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.67.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.9 |
 
 ## Modules
 
@@ -200,6 +200,7 @@ No modules.
 | [aws_iam_role.trigger](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.codedeploy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_s3_bucket.pipeline](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_acl.pipeline](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_acl) | resource |
 | [aws_s3_bucket_policy.cloudtrail](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [aws_s3_bucket_public_access_block.source](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
 | [aws_sns_topic.notifications](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic) | resource |

--- a/modules/deployment/README.md
+++ b/modules/deployment/README.md
@@ -173,7 +173,7 @@ resource "aws_s3_bucket_object" "source" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.67.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.9 |
 
 ## Modules
 

--- a/modules/deployment/README.md
+++ b/modules/deployment/README.md
@@ -173,7 +173,7 @@ resource "aws_s3_bucket_object" "source" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.9 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.67.0 |
 
 ## Modules
 

--- a/modules/deployment/main.tf
+++ b/modules/deployment/main.tf
@@ -94,10 +94,16 @@ resource "aws_codepipeline" "this" {
 resource "aws_s3_bucket" "pipeline" {
   count = var.codepipeline_artifact_store_bucket == "" ? 1 : 0
 
-  acl           = "private"
   bucket        = "${var.function_name}-pipeline-${data.aws_caller_identity.current.account_id}-${data.aws_region.current.name}"
   force_destroy = true
   tags          = var.tags
+}
+
+resource "aws_s3_bucket_acl" "pipeline" {
+  count = var.codepipeline_artifact_store_bucket == "" ? 1 : 0
+
+  acl    = "private"
+  bucket = aws_s3_bucket.pipeline[count.index].id
 }
 
 resource "aws_s3_bucket_public_access_block" "source" {


### PR DESCRIPTION
**What**

Optionally there can be a `cloudwatch_event_target_input` added.

**Why**

This is useful to identify different trigger types of the same lambda.