### PR TITLE
Add iam_role_name override variable and ensure generated name does not exceed 64 chars

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -1,3 +1,9 @@
+locals {
+  generated_iam_role_name = "${var.function_name}-${data.aws_region.current.name}"
+  safe_generated_iam_role_name = length(local.generated_iam_role_name) > 64 ? sha256(local.generated_iam_role_name) : local.generated_iam_role_name
+  iam_role_name = var.iam_role_name != null ? var.iam_role_name : local.safe_generated_iam_role_name
+}
+
 data "aws_iam_policy_document" "assume_role_policy" {
   statement {
     actions = ["sts:AssumeRole"]
@@ -10,7 +16,7 @@ data "aws_iam_policy_document" "assume_role_policy" {
 }
 
 resource "aws_iam_role" "lambda" {
-  name               = "${var.function_name}-${data.aws_region.current.name}"
+  name               = local.iam_role_name
   assume_role_policy = data.aws_iam_policy_document.assume_role_policy.json
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -223,3 +223,9 @@ variable "vpc_config" {
     subnet_ids         = list(string)
   })
 }
+
+variable "iam_role_name" {
+  description = "Override the name of the IAM role for the function. Otherwise the default will be your function name with the region as a suffix (or the sha256 hash if that exceeds 64 characters)"
+  default     = null
+  type        = string
+}


### PR DESCRIPTION
This PR adds two things related to the IAM role name:
- You can specify your own name via `iam_role_name` input variable.
- If the autogenerated name exceeds the AWS 64 character limit, it is sha256 hashed and that string is used instead.


I'm having difficulty executing the tests, otherwise I would most certainly add to the test coverage.