### PR TITLE
chore: updated min. aws provider version to 4.40

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ should migrate to this module as a drop-in replacement to benefit from new featu
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.9 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.40 |
 
 ## Providers
 

--- a/docs/deployment/part2.md
+++ b/docs/deployment/part2.md
@@ -3,7 +3,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.9 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.40 |
 
 ## Providers
 

--- a/docs/part2.md
+++ b/docs/part2.md
@@ -3,7 +3,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.9 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.40 |
 
 ## Providers
 

--- a/examples/container-image/versions.tf
+++ b/examples/container-image/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.9"
+      version = ">= 4.40"
     }
     null = {
       source  = "hashicorp/null"

--- a/examples/deployment/container-image/versions.tf
+++ b/examples/deployment/container-image/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.9"
+      version = ">= 4.40"
     }
     null = {
       source  = "hashicorp/null"

--- a/examples/deployment/s3/versions.tf
+++ b/examples/deployment/s3/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.9"
+      version = ">= 4.40"
     }
   }
 }

--- a/examples/simple/versions.tf
+++ b/examples/simple/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.9"
+      version = ">= 4.40"
     }
   }
 }

--- a/examples/with-cloudwatch-event-rules/versions.tf
+++ b/examples/with-cloudwatch-event-rules/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.9"
+      version = ">= 4.40"
     }
   }
 }

--- a/examples/with-cloudwatch-logs-subscription/versions.tf
+++ b/examples/with-cloudwatch-logs-subscription/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.9"
+      version = ">= 4.40"
     }
   }
 }

--- a/examples/with-event-source-mappings/dynamodb-with-alias/versions.tf
+++ b/examples/with-event-source-mappings/dynamodb-with-alias/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.9"
+      version = ">= 4.40"
     }
     archive = {
       source  = "hashicorp/archive"

--- a/examples/with-event-source-mappings/kinesis/versions.tf
+++ b/examples/with-event-source-mappings/kinesis/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.9"
+      version = ">= 4.40"
     }
     archive = {
       source  = "hashicorp/archive"

--- a/examples/with-event-source-mappings/sqs/versions.tf
+++ b/examples/with-event-source-mappings/sqs/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.9"
+      version = ">= 4.40"
     }
     archive = {
       source  = "hashicorp/archive"

--- a/examples/with-sns-subscriptions/versions.tf
+++ b/examples/with-sns-subscriptions/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.9"
+      version = ">= 4.40"
     }
     archive = {
       source  = "hashicorp/archive"

--- a/main.tf
+++ b/main.tf
@@ -130,7 +130,7 @@ resource "aws_lambda_function" "lambda_external_lifecycle" {
 
   lifecycle {
     ignore_changes = [
-      image_uri, last_modified, qualified_arn, s3_object_version, version
+      image_uri, qualified_arn, s3_object_version, version
     ]
   }
 }

--- a/modules/deployment/README.md
+++ b/modules/deployment/README.md
@@ -167,7 +167,7 @@ resource "aws_s3_bucket_object" "source" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.9 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.40 |
 
 ## Providers
 

--- a/modules/deployment/versions.tf
+++ b/modules/deployment/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.0"
 
   required_providers {
-    aws = ">= 4.9"
+    aws = ">= 4.40"
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.0"
 
   required_providers {
-    aws = ">= 4.9"
+    aws = ">= 4.40"
   }
 }


### PR DESCRIPTION
In addition, silenced `terraform validate` warning

>  The attribute last_modified is decided by the provider alone and therefore there can be no configured value to compare with. Including this attribute in ignore_changes has no effect. Remove the attribute from ignore_changes to quiet this warning.
