### PR TITLE
chore: removed ignored attributes computed by aws provider

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -138,7 +138,7 @@ resource "aws_lambda_function" "lambda_external_lifecycle" {
 
   lifecycle {
     ignore_changes = [
-      image_uri, qualified_arn, s3_object_version, version
+      image_uri, s3_object_version
     ]
   }
 }


### PR DESCRIPTION
this will silence those terraform warnings:

```
╷
│ Warning: Redundant ignore_changes element
│ 
│   on ../../main.tf line 79, in resource "aws_lambda_function" "lambda_external_lifecycle":
│   79: resource "aws_lambda_function" "lambda_external_lifecycle" {
│ 
│ Adding an attribute name to ignore_changes tells Terraform to ignore future changes to the argument in configuration after the object has been created, retaining the value originally configured.
│ 
│ The attribute version is decided by the provider alone and therefore there can be no configured value to compare with. Including this attribute in ignore_changes has no effect. Remove the attribute from ignore_changes to quiet this warning.
╵

```
