### PR TITLE
fix(deployment): use dynamic blocks for alarm and rollback configurations in CodeDeploy

### DIFF
--- a/modules/deployment/README.md
+++ b/modules/deployment/README.md
@@ -18,7 +18,7 @@ to update the function code and CodeDeploy to deploy the new function version.
 - creation of IAM roles with permissions following the [principle of least privilege](https://en.wikipedia.org/wiki/Principle_of_least_privilege) for CodePipeline, CodeBuild and CodeDeploy
   or bring your own roles
 - SNS topic for [AWS CodeStar Notifications](https://docs.aws.amazon.com/dtconsole/latest/userguide/welcome.html) of CodePipeline events, or bring your own SNS topic
-- `BeforeAllowTraffic` and `AfterAllowTraffic` [hooks](https://docs.aws.amazon.com/codedeploy/latest/userguide/reference-appspec-file-structure-hooks.html#appspec-hooks-lambda) CodeDeploy
+- `BeforeAllowTraffic` and `AfterAllowTraffic` [hooks](https://docs.aws.amazon.com/codedeploy/latest/userguide/reference-appspec-file-structure-hooks.html#appspec-hooks-lambda) for CodeDeploy
 - AWS predefined and custom [deployment configurations](https://docs.aws.amazon.com/codedeploy/latest/userguide/deployment-configurations.html) for CodeDeploy
 - automatic [rollbacks](https://docs.aws.amazon.com/codedeploy/latest/userguide/deployments-rollback-and-redeploy.html#deployments-rollback-and-redeploy-automatic-rollbacks) and support of [CloudWatch alarms](https://docs.aws.amazon.com/codedeploy/latest/userguide/deployment-groups-configure-advanced-options.html) to stop deployments
 

--- a/modules/deployment/codedeploy.tf
+++ b/modules/deployment/codedeploy.tf
@@ -9,15 +9,21 @@ resource "aws_codedeploy_deployment_group" "this" {
   deployment_group_name  = var.alias_name
   service_role_arn       = aws_iam_role.codedeploy.arn
 
-  alarm_configuration {
-    alarms                    = var.codedeploy_deployment_group_alarm_configuration_alarms
-    enabled                   = var.codedeploy_deployment_group_alarm_configuration_enabled
-    ignore_poll_alarm_failure = var.codedeploy_deployment_group_alarm_configuration_ignore_poll_alarm_failure
+  dynamic "alarm_configuration" {
+    for_each = var.codedeploy_deployment_group_alarm_configuration_enabled ? [true] : []
+    content {
+      alarms                    = var.codedeploy_deployment_group_alarm_configuration_alarms
+      enabled                   = var.codedeploy_deployment_group_alarm_configuration_enabled
+      ignore_poll_alarm_failure = var.codedeploy_deployment_group_alarm_configuration_ignore_poll_alarm_failure
+    }
   }
 
-  auto_rollback_configuration {
-    enabled = var.codedeploy_deployment_group_auto_rollback_configuration_enabled
-    events  = var.codedeploy_deployment_group_auto_rollback_configuration_events
+  dynamic "auto_rollback_configuration" {
+    for_each = var.codedeploy_deployment_group_auto_rollback_configuration_enabled ? [true] : []
+    content {
+      enabled = var.codedeploy_deployment_group_auto_rollback_configuration_enabled
+      events  = var.codedeploy_deployment_group_auto_rollback_configuration_events
+    }
   }
 
   deployment_style {


### PR DESCRIPTION
## why

remove unnecessary terraform infrastructure changes if rollback or alarm configuration is not used in CodeDeploy