### PR TITLE
feat: code pipeline names can be up to 100 characters

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -1,5 +1,10 @@
 locals {
-  iam_role_name = coalesce(var.iam_role_name, "${var.function_name}-${data.aws_region.current.name}")
+  // calculate the maximum length for default IAM role including
+  // region suffix. Role name must not exceed 64 characters,
+  // see https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html
+  iam_role_name_max_prefix_length = 64 - length("-${data.aws_region.current.name}")
+  iam_role_prefix                 = substr(var.function_name, 0, local.iam_role_name_max_prefix_length)
+  iam_role_name                   = coalesce(var.iam_role_name, "${local.iam_role_prefix}-${data.aws_region.current.name}")
 }
 
 data "aws_iam_policy_document" "assume_role_policy" {

--- a/modules/deployment/README.md
+++ b/modules/deployment/README.md
@@ -392,7 +392,6 @@ No modules.
 | [aws_iam_role.trigger](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.codedeploy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_s3_bucket.pipeline](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
-| [aws_s3_bucket_acl.pipeline](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_acl) | resource |
 | [aws_s3_bucket_public_access_block.source](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
 | [aws_s3_bucket_server_side_encryption_configuration.pipeline](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
 | [aws_sns_topic.notifications](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic) | resource |

--- a/modules/deployment/iam_codebuild.tf
+++ b/modules/deployment/iam_codebuild.tf
@@ -50,14 +50,14 @@ resource "aws_iam_role" "codebuild_role" {
             "s3:GetObjectVersion"
           ]
           Effect   = "Allow"
-          Resource = "${local.artifact_store_bucket_arn}/${local.pipeline_name}/source/*"
+          Resource = "${local.artifact_store_bucket_arn}/${local.pipeline_artifacts_folder}/source/*"
         },
         {
           Action = [
             "s3:PutObject",
           ]
           Effect   = "Allow"
-          Resource = "${local.artifact_store_bucket_arn}/${local.pipeline_name}/${local.deploy_output}/*"
+          Resource = "${local.artifact_store_bucket_arn}/${local.pipeline_artifacts_folder}/${local.deploy_output}/*"
         }
       ]
     })

--- a/modules/deployment/iam_codebuild.tf
+++ b/modules/deployment/iam_codebuild.tf
@@ -1,7 +1,7 @@
 resource "aws_iam_role" "codebuild_role" {
   count = var.codebuild_role_arn == "" ? 1 : 0
 
-  name = "${var.function_name}-codebuild-${data.aws_region.current.name}"
+  name = "${local.iam_role_prefix}-codebuild-${data.aws_region.current.name}"
   tags = var.tags
 
   assume_role_policy = jsonencode({
@@ -19,7 +19,7 @@ resource "aws_iam_role" "codebuild_role" {
   })
 
   inline_policy {
-    name = "${var.function_name}-codebuild-${data.aws_region.current.name}"
+    name = "lambda-update-function-code-permissions"
 
     policy = jsonencode({
       Version = "2012-10-17"
@@ -66,7 +66,7 @@ resource "aws_iam_role" "codebuild_role" {
   dynamic "inline_policy" {
     for_each = var.s3_bucket != "" ? [true] : []
     content {
-      name = "${var.function_name}-codebuild-s3-${data.aws_region.current.name}"
+      name = "lambda-s3-package-permissions"
 
       policy = jsonencode({
         Version = "2012-10-17"

--- a/modules/deployment/iam_codedeploy.tf
+++ b/modules/deployment/iam_codedeploy.tf
@@ -28,7 +28,7 @@ resource "aws_iam_role" "codedeploy" {
             "s3:GetObjectVersion"
           ]
           Effect   = "Allow"
-          Resource = "${local.artifact_store_bucket_arn}/${local.pipeline_name}/${local.deploy_output}/*"
+          Resource = "${local.artifact_store_bucket_arn}/${local.pipeline_artifacts_folder}/${local.deploy_output}/*"
         }
       ]
     })

--- a/modules/deployment/iam_codedeploy.tf
+++ b/modules/deployment/iam_codedeploy.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_role" "codedeploy" {
-  name = "${var.function_name}-codedeploy-${data.aws_region.current.name}"
+  name = "${local.iam_role_prefix}-codedeploy-${data.aws_region.current.name}"
   tags = var.tags
 
   assume_role_policy = jsonencode({
@@ -17,7 +17,7 @@ resource "aws_iam_role" "codedeploy" {
   })
 
   inline_policy {
-    name = "s3"
+    name = "pipeline-artifacts-permissions"
 
     policy = jsonencode({
       Version = "2012-10-17"

--- a/modules/deployment/iam_codepipeline.tf
+++ b/modules/deployment/iam_codepipeline.tf
@@ -1,7 +1,7 @@
 resource "aws_iam_role" "codepipeline_role" {
   count = var.codepipeline_role_arn == "" ? 1 : 0
 
-  name = "${var.function_name}-codepipeline-${data.aws_region.current.name}"
+  name = "${local.iam_role_prefix}-codepipeline-${data.aws_region.current.name}"
   tags = var.tags
 
   assume_role_policy = jsonencode({
@@ -21,7 +21,7 @@ resource "aws_iam_role" "codepipeline_role" {
   dynamic "inline_policy" {
     for_each = var.s3_bucket != "" ? [true] : []
     content {
-      name = "${var.function_name}-codepipeline-s3-${data.aws_region.current.name}"
+      name = "s3-source-package-permissions"
 
       policy = jsonencode({
         Version = "2012-10-17"
@@ -45,7 +45,7 @@ resource "aws_iam_role" "codepipeline_role" {
   dynamic "inline_policy" {
     for_each = var.ecr_repository_name != "" ? [true] : []
     content {
-      name = "${var.function_name}-codepipeline-ecr-${data.aws_region.current.name}"
+      name = "ecr-source-image-permissions"
 
       policy = jsonencode({
         Version = "2012-10-17"
@@ -61,7 +61,7 @@ resource "aws_iam_role" "codepipeline_role" {
   }
 
   inline_policy {
-    name = "${var.function_name}-codepipeline-${data.aws_region.current.name}"
+    name = "codepipeline-permissions"
 
     policy = jsonencode({
       Version = "2012-10-17"

--- a/modules/deployment/iam_trigger.tf
+++ b/modules/deployment/iam_trigger.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_role" "trigger" {
-  name = "${var.function_name}-trigger-${data.aws_region.current.name}"
+  name = "${local.iam_role_prefix}-trigger-${data.aws_region.current.name}"
   tags = var.tags
 
   assume_role_policy = jsonencode({
@@ -17,7 +17,7 @@ resource "aws_iam_role" "trigger" {
   })
 
   inline_policy {
-    name = "${var.function_name}-trigger-${data.aws_region.current.name}"
+    name = "codepipeline-permissions"
 
     policy = jsonencode({
       Version = "2012-10-17"

--- a/modules/deployment/main.tf
+++ b/modules/deployment/main.tf
@@ -6,7 +6,8 @@ locals {
   artifact_store_bucket     = var.codepipeline_artifact_store_bucket != "" ? var.codepipeline_artifact_store_bucket : aws_s3_bucket.pipeline[0].bucket
   artifact_store_bucket_arn = "arn:${data.aws_partition.current.partition}:s3:::${local.artifact_store_bucket}"
   deploy_output             = "deploy"
-  pipeline_name             = substr(var.function_name, 0, 100)
+  pipeline_name             = substr(var.function_name, 0, 100)  // AWS CodePipeline has a limit of 100 characters for the pipeline name, see https://docs.aws.amazon.com/codepipeline/latest/userguide/limits.html
+  pipeline_artifacts_folder = substr(local.pipeline_name, 0, 20) // AWS CodePipeline truncates the name of the artifacts folder automatically
 }
 
 resource "aws_codepipeline" "this" {

--- a/modules/deployment/main.tf
+++ b/modules/deployment/main.tf
@@ -6,7 +6,7 @@ locals {
   artifact_store_bucket     = var.codepipeline_artifact_store_bucket != "" ? var.codepipeline_artifact_store_bucket : aws_s3_bucket.pipeline[0].bucket
   artifact_store_bucket_arn = "arn:${data.aws_partition.current.partition}:s3:::${local.artifact_store_bucket}"
   deploy_output             = "deploy"
-  pipeline_name             = substr(var.function_name, 0, 20)
+  pipeline_name             = substr(var.function_name, 0, 100)
 }
 
 resource "aws_codepipeline" "this" {

--- a/modules/deployment/notification.tf
+++ b/modules/deployment/notification.tf
@@ -18,7 +18,7 @@ resource "aws_codestarnotifications_notification_rule" "notification" {
 
   detail_type    = var.codestar_notifications_detail_type
   event_type_ids = var.codestar_notifications_event_type_ids
-  name           = "${var.function_name}-notifications-${data.aws_region.current.name}"
+  name           = "${local.iam_role_prefix}-notifications-${data.aws_region.current.name}"
   resource       = aws_codepipeline.this.arn
   tags           = var.tags
 

--- a/modules/deployment/outputs.tf
+++ b/modules/deployment/outputs.tf
@@ -40,7 +40,7 @@ output "codepipeline_arn" {
 
 output "codepipeline_artifact_storage_arn" {
   description = "The Amazon Resource Name (ARN) of the CodePipeline artifact store."
-  value       = "${local.artifact_store_bucket_arn}/${local.pipeline_name}"
+  value       = "${local.artifact_store_bucket_arn}/${local.pipeline_artifacts_folder}"
 }
 
 output "codepipeline_id" {

--- a/modules/deployment/trigger_s3.tf
+++ b/modules/deployment/trigger_s3.tf
@@ -1,7 +1,7 @@
 resource "aws_cloudwatch_event_rule" "s3_trigger" {
   count = var.s3_bucket != "" ? 1 : 0
 
-  name        = "${var.function_name}-s3-trigger"
+  name        = "${local.iam_role_prefix}-s3-trigger"
   description = "Amazon CloudWatch Events rule to automatically start the pipeline when a change occurs in the Amazon S3 object key or S3 folder."
   tags        = var.tags
 


### PR DESCRIPTION
## what

- allow up to 100 characters in CodePipeline names, see "Characters allowed in a pipeline name" in [Service Limits](https://docs.aws.amazon.com/codepipeline/latest/userguide/limits.html)
- failsafe name length for default resources like IAM roles and S3 buckets