### PR TITLE
feat: allow setting of retry policy for cloudwatch event targets

### DIFF
--- a/cloudwatch_event_rules.tf
+++ b/cloudwatch_event_rules.tf
@@ -30,7 +30,7 @@ resource "aws_cloudwatch_event_target" "lambda" {
   rule           = aws_cloudwatch_event_rule.lambda[each.key].name
   input          = lookup(each.value, "cloudwatch_event_target_input", null)
   retry_policy {
-    maximum_event_age_in_seconds = lookup(each.value, "cloudwatch_event_target_retry_policy_maximum_event_age_in_seconds", null)
-    maximum_retry_attempts       = lookup(each.value, "cloudwatch_event_target_retry_policy_maximum_retry_attempts", null)
+    maximum_event_age_in_seconds = null
+    maximum_retry_attempts       = null
   }
 }

--- a/cloudwatch_event_rules.tf
+++ b/cloudwatch_event_rules.tf
@@ -29,4 +29,8 @@ resource "aws_cloudwatch_event_target" "lambda" {
   arn            = lookup(each.value, "cloudwatch_event_target_arn", local.function_arn)
   rule           = aws_cloudwatch_event_rule.lambda[each.key].name
   input          = lookup(each.value, "cloudwatch_event_target_input", null)
+  retry_policy {
+    maximum_event_age_in_seconds = lookup(each.value, "cloudwatch_event_target_retry_policy_maximum_event_age_in_seconds", null)
+    maximum_retry_attempts       = lookup(each.value, "cloudwatch_event_target_retry_policy_maximum_retry_attempts", null)
+  }
 }

--- a/cloudwatch_event_rules.tf
+++ b/cloudwatch_event_rules.tf
@@ -1,3 +1,8 @@
+locals {
+  # https://aws.amazon.com/about-aws/whats-new/2019/11/aws-lambda-supports-max-retry-attempts-event-age-asynchronous-invocations/
+  default_cloudwatch_event_target_retry_policy_maximum_event_age_in_seconds = 6 * 60 * 60 # 6 hours
+  default_cloudwatch_event_target_retry_policy_maximum_retry_attempts       = 2
+}
 resource "aws_lambda_permission" "cloudwatch_events" {
   for_each = var.cloudwatch_event_rules
 
@@ -29,8 +34,9 @@ resource "aws_cloudwatch_event_target" "lambda" {
   arn            = lookup(each.value, "cloudwatch_event_target_arn", local.function_arn)
   rule           = aws_cloudwatch_event_rule.lambda[each.key].name
   input          = lookup(each.value, "cloudwatch_event_target_input", null)
+
   retry_policy {
-    maximum_event_age_in_seconds = null
-    maximum_retry_attempts       = null
+    maximum_event_age_in_seconds = lookup(each.value, "cloudwatch_event_target_retry_policy_maximum_event_age_in_seconds", local.default_cloudwatch_event_target_retry_policy_maximum_event_age_in_seconds)
+    maximum_retry_attempts       = lookup(each.value, "cloudwatch_event_target_retry_policy_maximum_retry_attempts", local.default_cloudwatch_event_target_retry_policy_maximum_retry_attempts)
   }
 }

--- a/examples/with-cloudwatch-event-rules/main.tf
+++ b/examples/with-cloudwatch-event-rules/main.tf
@@ -30,6 +30,12 @@ module "lambda" {
 
       // optionally add `cloudwatch_event_target_input` for event input
       cloudwatch_event_target_input = jsonencode({ "key" : "value" })
+
+      // optionally add cloudwatch_event_target_retry_policy_maximum_event_age_in_seconds
+      cloudwatch_event_target_retry_policy_maximum_event_age_in_seconds = 20
+
+      // optionally add cloudwatch_event_target_retry_policy_maximum_retry_attempts
+      cloudwatch_event_target_retry_policy_maximum_retry_attempts = 0
     }
 
     pattern = {


### PR DESCRIPTION
address [126](https://github.com/moritzzimmer/terraform-aws-lambda/issues/126)

This PR just uses the existing patterns to send down retry configuration for cloudwatch event targets if specified. 