### PR TITLE
feat: use inline instead of customer managed IAM policies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ providers: ## Upgrades all providers and platform independent dependency locks (
 	@for s in $(STACKS) ; do \
   		echo upgrading: $$s ;\
 		terraform -chdir=$$s init -upgrade=true -backend=false > /dev/null; \
-		terraform -chdir=$$s providers lock -platform=darwin_amd64 -platform=linux_amd64 ;\
+		terraform -chdir=$$s providers lock -platform=darwin_amd64 -platform=darwin_arm64 -platform=linux_amd64 ;\
 	done
 
 .PHONY: bump-version
@@ -104,7 +104,7 @@ update: ## Upgrades Terraform core and providers constraints recursively using h
 	@echo "+ $@"
 	@command -v tfupdate >/dev/null 2>&1 || { echo >&2 "Please install tfupdate: 'brew install minamijoyo/tfupdate/tfupdate'"; exit 1; }
 	@tfupdate terraform -v ">= 1.3" -r .
-	@tfupdate provider aws -v ">= 5.32" -r .
+	@tfupdate provider aws -v ">= 5.82.2" -r .
 	@tfupdate provider archive -v ">= 2.2" -r .
 	@tfupdate provider null -v ">= 3.2" -r .
 

--- a/README.md
+++ b/README.md
@@ -339,19 +339,19 @@ MINOR, and PATCH versions on each release to indicate any incompatibilities.
 Implementation of this module started at [Spring Media/Welt](https://github.com/spring-media/terraform-aws-lambda). Users of `spring-media/lambda/aws`
 should migrate to this module as a drop-in replacement to benefit from new features and bugfixes.
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.82.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.82.2 |
 
 ## Modules
 
@@ -365,16 +365,13 @@ No modules.
 | [aws_cloudwatch_event_target.lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
 | [aws_cloudwatch_log_group.lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_cloudwatch_log_subscription_filter.cloudwatch_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_subscription_filter) | resource |
-| [aws_iam_policy.event_sources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
-| [aws_iam_policy.logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
-| [aws_iam_policy.ssm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
-| [aws_iam_role_policy_attachment.cloudwatch_lambda_insights](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.event_sources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.ssm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.tracing_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.vpc_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy.event_sources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.lambda_insights](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.ssm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.tracing](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_lambda_event_source_mapping.event_source](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_event_source_mapping) | resource |
 | [aws_lambda_function.lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
 | [aws_lambda_function.lambda_external_lifecycle](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
@@ -383,6 +380,9 @@ No modules.
 | [aws_lambda_permission.sns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
 | [aws_sns_topic_subscription.subscription](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic_subscription) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy.lambda_insights](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy) | data source |
+| [aws_iam_policy.tracing](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy) | data source |
+| [aws_iam_policy.vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy) | data source |
 | [aws_iam_policy_document.assume_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.event_sources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -402,7 +402,7 @@ No modules.
 | <a name="input_cloudwatch_logs_kms_key_id"></a> [cloudwatch\_logs\_kms\_key\_id](#input\_cloudwatch\_logs\_kms\_key\_id) | The ARN of the KMS Key to use when encrypting log data. | `string` | `null` | no |
 | <a name="input_cloudwatch_logs_retention_in_days"></a> [cloudwatch\_logs\_retention\_in\_days](#input\_cloudwatch\_logs\_retention\_in\_days) | Specifies the number of days you want to retain log events in the specified log group. Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653, and 0. If you select 0, the events in the log group are always retained and never expire. | `number` | `null` | no |
 | <a name="input_description"></a> [description](#input\_description) | Description of what your Lambda Function does. | `string` | `"Instruction set architecture for your Lambda function. Valid values are [\"x86_64\"] and [\"arm64\"]."` | no |
-| <a name="input_environment"></a> [environment](#input\_environment) | Environment (e.g. env variables) configuration for the Lambda function enable you to dynamically pass settings to your function code and libraries | <pre>object({<br>    variables = map(string)<br>  })</pre> | `null` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment (e.g. env variables) configuration for the Lambda function enable you to dynamically pass settings to your function code and libraries | <pre>object({<br/>    variables = map(string)<br/>  })</pre> | `null` | no |
 | <a name="input_ephemeral_storage_size"></a> [ephemeral\_storage\_size](#input\_ephemeral\_storage\_size) | The size of your Lambda functions ephemeral storage (/tmp) represented in MB. Valid value between 512 MB to 10240 MB. | `number` | `512` | no |
 | <a name="input_event_source_mappings"></a> [event\_source\_mappings](#input\_event\_source\_mappings) | Creates event source mappings to allow the Lambda function to get events from Kinesis, DynamoDB and SQS. The IAM role of this Lambda function will be enhanced with necessary minimum permissions to get those events. | `any` | `{}` | no |
 | <a name="input_filename"></a> [filename](#input\_filename) | The path to the function's deployment package within the local filesystem. If defined, The s3\_-prefixed options and image\_uri cannot be used. | `string` | `null` | no |
@@ -410,7 +410,7 @@ No modules.
 | <a name="input_handler"></a> [handler](#input\_handler) | The function entrypoint in your code. | `string` | `""` | no |
 | <a name="input_iam_role_name"></a> [iam\_role\_name](#input\_iam\_role\_name) | Override the name of the IAM role for the function. Otherwise the default will be your function name with the region as a suffix. | `string` | `null` | no |
 | <a name="input_ignore_external_function_updates"></a> [ignore\_external\_function\_updates](#input\_ignore\_external\_function\_updates) | Ignore updates to your Lambda function executed externally to the Terraform lifecycle. Set this to `true` if you're using CodeDeploy, aws CLI or other external tools to update your Lambda function code. | `bool` | `false` | no |
-| <a name="input_image_config"></a> [image\_config](#input\_image\_config) | The Lambda OCI [image configurations](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function#image_config) block with three (optional) arguments:<br><br>  - *entry\_point* - The ENTRYPOINT for the docker image (type `list(string)`).<br>  - *command* - The CMD for the docker image (type `list(string)`).<br>  - *working\_directory* - The working directory for the docker image (type `string`). | `any` | `{}` | no |
+| <a name="input_image_config"></a> [image\_config](#input\_image\_config) | The Lambda OCI [image configurations](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function#image_config) block with three (optional) arguments:<br/><br/>  - *entry\_point* - The ENTRYPOINT for the docker image (type `list(string)`).<br/>  - *command* - The CMD for the docker image (type `list(string)`).<br/>  - *working\_directory* - The working directory for the docker image (type `string`). | `any` | `{}` | no |
 | <a name="input_image_uri"></a> [image\_uri](#input\_image\_uri) | The ECR image URI containing the function's deployment package. Conflicts with filename, s3\_bucket, s3\_key, and s3\_object\_version. | `string` | `null` | no |
 | <a name="input_kms_key_arn"></a> [kms\_key\_arn](#input\_kms\_key\_arn) | Amazon Resource Name (ARN) of the AWS Key Management Service (KMS) key that is used to encrypt environment variables. If this configuration is not provided when environment variables are in use, AWS Lambda uses a default service key. If this configuration is provided when environment variables are not in use, the AWS Lambda API does not save this configuration and Terraform will show a perpetual difference of adding the key. To fix the perpetual difference, remove this configuration. | `string` | `""` | no |
 | <a name="input_lambda_at_edge"></a> [lambda\_at\_edge](#input\_lambda\_at\_edge) | Enable Lambda@Edge for your Node.js or Python functions. Required trust relationship and publishing of function versions will be configured. | `bool` | `false` | no |
@@ -428,11 +428,11 @@ No modules.
 | <a name="input_snap_start"></a> [snap\_start](#input\_snap\_start) | Enable snap start settings for low-latency startups. This feature is currently only supported for `java11` and `java17` runtimes and `x86_64` architectures. | `bool` | `false` | no |
 | <a name="input_sns_subscriptions"></a> [sns\_subscriptions](#input\_sns\_subscriptions) | Creates subscriptions to SNS topics which trigger your Lambda function. Required Lambda invocation permissions will be generated. | `map(any)` | `{}` | no |
 | <a name="input_source_code_hash"></a> [source\_code\_hash](#input\_source\_code\_hash) | Used to trigger updates. Must be set to a base64-encoded SHA256 hash of the package file specified with either filename or s3\_key. The usual way to set this is filebase64sha256('file.zip') where 'file.zip' is the local filename of the lambda function source archive. | `string` | `""` | no |
-| <a name="input_ssm"></a> [ssm](#input\_ssm) | List of AWS Systems Manager Parameter Store parameter names. The IAM role of this Lambda function will be enhanced with read permissions for those parameters. Parameters must start with a forward slash and can be encrypted with the default KMS key. | <pre>object({<br>    parameter_names = list(string)<br>  })</pre> | `null` | no |
+| <a name="input_ssm"></a> [ssm](#input\_ssm) | List of AWS Systems Manager Parameter Store parameter names. The IAM role of this Lambda function will be enhanced with read permissions for those parameters. Parameters must start with a forward slash and can be encrypted with the default KMS key. | <pre>object({<br/>    parameter_names = list(string)<br/>  })</pre> | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to the Lambda function and all resources supporting tags. | `map(string)` | `{}` | no |
 | <a name="input_timeout"></a> [timeout](#input\_timeout) | The amount of time your Lambda Function has to run in seconds. | `number` | `3` | no |
 | <a name="input_tracing_config_mode"></a> [tracing\_config\_mode](#input\_tracing\_config\_mode) | Tracing config mode of the Lambda function. Can be either PassThrough or Active. | `string` | `null` | no |
-| <a name="input_vpc_config"></a> [vpc\_config](#input\_vpc\_config) | Provide this to allow your function to access your VPC (if both `subnet_ids` and `security_group_ids` are empty then vpc\_config is considered to be empty or unset, see https://docs.aws.amazon.com/lambda/latest/dg/vpc.html for details). | <pre>object({<br>    ipv6_allowed_for_dual_stack = optional(bool, false)<br>    security_group_ids          = list(string)<br>    subnet_ids                  = list(string)<br>  })</pre> | `null` | no |
+| <a name="input_vpc_config"></a> [vpc\_config](#input\_vpc\_config) | Provide this to allow your function to access your VPC (if both `subnet_ids` and `security_group_ids` are empty then vpc\_config is considered to be empty or unset, see https://docs.aws.amazon.com/lambda/latest/dg/vpc.html for details). | <pre>object({<br/>    ipv6_allowed_for_dual_stack = optional(bool, false)<br/>    security_group_ids          = list(string)<br/>    subnet_ids                  = list(string)<br/>  })</pre> | `null` | no |
 
 ## Outputs
 
@@ -446,4 +446,4 @@ No modules.
 | <a name="output_role_arn"></a> [role\_arn](#output\_role\_arn) | The ARN of the IAM role attached to the Lambda Function. |
 | <a name="output_role_name"></a> [role\_name](#output\_role\_name) | The name of the IAM role attached to the Lambda Function. |
 | <a name="output_version"></a> [version](#output\_version) | Latest published version of your Lambda Function. |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->

--- a/event_source_mappings.tf
+++ b/event_source_mappings.tf
@@ -191,14 +191,10 @@ data "aws_iam_policy_document" "event_sources" {
   }
 }
 
-resource "aws_iam_policy" "event_sources" {
-  count  = length(var.event_source_mappings) > 0 ? 1 : 0
-  policy = data.aws_iam_policy_document.event_sources[count.index].json
-}
-
-resource "aws_iam_role_policy_attachment" "event_sources" {
+resource "aws_iam_role_policy" "event_sources" {
   count = length(var.event_source_mappings) > 0 ? 1 : 0
 
-  policy_arn = aws_iam_policy.event_sources[count.index].arn
-  role       = aws_iam_role.lambda.name
+  name   = "${var.function_name}-event-source-mapping"
+  policy = data.aws_iam_policy_document.event_sources[count.index].json
+  role   = aws_iam_role.lambda.id
 }

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -12,34 +12,31 @@ terraform apply
 
 Note that this example may create resources which cost money. Run `terraform destroy` to destroy those resources.
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.5 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.82.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32 |
-| <a name="provider_random"></a> [random](#provider\_random) | >= 3.5 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.82.2 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
+| <a name="module_fixtures"></a> [fixtures](#module\_fixtures) | ../fixtures | n/a |
 | <a name="module_lambda"></a> [lambda](#module\_lambda) | ../../ | n/a |
-| <a name="module_source"></a> [source](#module\_source) | ../fixtures | n/a |
 
 ## Resources
 
 | Name | Type |
 |------|------|
-| [random_pet.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs
@@ -56,4 +53,4 @@ Note that this example may create resources which cost money. Run `terraform des
 | <a name="output_cloudwatch_log_group_name"></a> [cloudwatch\_log\_group\_name](#output\_cloudwatch\_log\_group\_name) | The name of the CloudWatch log group used by your Lambda function. |
 | <a name="output_function_name"></a> [function\_name](#output\_function\_name) | The unique name of your Lambda Function. |
 | <a name="output_role_name"></a> [role\_name](#output\_role\_name) | The name of the IAM role attached to the Lambda Function. |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -1,11 +1,7 @@
 data "aws_region" "current" {}
 
-module "source" {
+module "fixtures" {
   source = "../fixtures"
-}
-
-resource "random_pet" "this" {
-  length = 2
 }
 
 module "lambda" {
@@ -14,21 +10,22 @@ module "lambda" {
   architectures          = ["arm64"]
   description            = "Example AWS Lambda function without any triggers."
   ephemeral_storage_size = 512
-  filename               = module.source.output_path
-  function_name          = random_pet.this.id
+  filename               = module.fixtures.output_path
+  function_name          = module.fixtures.output_function_name
   handler                = "index.handler"
   memory_size            = 128
-  runtime                = "nodejs20.x"
+  runtime                = "nodejs22.x"
   publish                = false
   snap_start             = false
-  source_code_hash       = module.source.output_base64sha256
+  source_code_hash       = module.fixtures.output_base64sha256
   timeout                = 3
+  tracing_config_mode    = "Active"
 
   // logs and metrics
   cloudwatch_logs_enabled            = true
   cloudwatch_logs_retention_in_days  = 7
   cloudwatch_lambda_insights_enabled = true
-  layers                             = ["arn:aws:lambda:${data.aws_region.current.id}:580247275435:layer:LambdaInsightsExtension-Arm64:5"]
+  layers                             = ["arn:aws:lambda:${data.aws_region.current.id}:580247275435:layer:LambdaInsightsExtension-Arm64:20"]
 
   environment = {
     variables = {

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,11 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32"
-    }
-    random = {
-      source  = "hashicorp/random"
-      version = ">= 3.5"
+      version = ">= 5.82.2"
     }
   }
 }

--- a/examples/container-image/README.md
+++ b/examples/container-image/README.md
@@ -12,26 +12,27 @@ terraform apply
 
 Note that this example may create resources which cost money. Run `terraform destroy` to destroy those resources.
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.82.2 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.82.2 |
 | <a name="provider_null"></a> [null](#provider\_null) | >= 3.2 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
+| <a name="module_fixtures"></a> [fixtures](#module\_fixtures) | ../fixtures | n/a |
 | <a name="module_lambda"></a> [lambda](#module\_lambda) | ../../ | n/a |
 
 ## Resources
@@ -50,4 +51,4 @@ Note that this example may create resources which cost money. Run `terraform des
 ## Outputs
 
 No outputs.
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->

--- a/examples/container-image/main.tf
+++ b/examples/container-image/main.tf
@@ -1,6 +1,10 @@
+module "fixtures" {
+  source = "../fixtures"
+}
+
 locals {
   environment   = "production"
-  function_name = "example-with-container-images"
+  function_name = module.fixtures.output_function_name
 }
 
 #trivy:ignore:AVD-AWS-0031

--- a/examples/container-image/versions.tf
+++ b/examples/container-image/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32"
+      version = ">= 5.82.2"
     }
     null = {
       source  = "hashicorp/null"

--- a/examples/deployment/complete/README.md
+++ b/examples/deployment/complete/README.md
@@ -25,28 +25,28 @@ Upload a new `zip` package to S3 to start the deployment pipeline:
 aws s3api put-object --bucket example-ci-{account_id}-{region} --key deployment-hooks/package/lambda.zip --body lambda.zip
 ```
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
 | <a name="requirement_archive"></a> [archive](#requirement\_archive) | >= 2.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.82.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_archive"></a> [archive](#provider\_archive) | >= 2.2 |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.82.2 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_deployment"></a> [deployment](#module\_deployment) | ../../../modules/deployment | n/a |
-| <a name="module_function"></a> [function](#module\_function) | ../../fixtures | n/a |
+| <a name="module_fixtures"></a> [fixtures](#module\_fixtures) | ../../fixtures | n/a |
 | <a name="module_lambda"></a> [lambda](#module\_lambda) | ../../../ | n/a |
 | <a name="module_traffic_hook"></a> [traffic\_hook](#module\_traffic\_hook) | ../../../ | n/a |
 
@@ -87,4 +87,4 @@ aws s3api put-object --bucket example-ci-{account_id}-{region} --key deployment-
 ## Outputs
 
 No outputs.
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->

--- a/examples/deployment/complete/main.tf
+++ b/examples/deployment/complete/main.tf
@@ -1,13 +1,13 @@
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 
-module "function" {
+module "fixtures" {
   source = "../../fixtures"
 }
 
 locals {
   environment   = "production"
-  function_name = "deployment-hooks"
+  function_name = module.fixtures.output_function_name
   s3_key        = "${local.function_name}/package/lambda.zip"
 }
 
@@ -20,7 +20,7 @@ module "lambda" {
   handler                          = "index.handler"
   ignore_external_function_updates = true
   publish                          = true
-  runtime                          = "nodejs20.x"
+  runtime                          = "nodejs22.x"
   s3_bucket                        = aws_s3_bucket.source.bucket
   s3_key                           = local.s3_key
   s3_object_version                = aws_s3_object.initial.version_id
@@ -239,8 +239,8 @@ resource "aws_s3_bucket_public_access_block" "source" {
 resource "aws_s3_object" "initial" {
   bucket = aws_s3_bucket.source.bucket
   key    = local.s3_key
-  source = module.function.output_path
-  etag   = module.function.output_md5
+  source = module.fixtures.output_path
+  etag   = module.fixtures.output_md5
 
   lifecycle {
     ignore_changes = [etag]

--- a/examples/deployment/complete/versions.tf
+++ b/examples/deployment/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32"
+      version = ">= 5.82.2"
     }
     archive = {
       source  = "hashicorp/archive"

--- a/examples/deployment/container-image/README.md
+++ b/examples/deployment/container-image/README.md
@@ -21,20 +21,20 @@ docker build --tag {account_id}.dkr.ecr.{region}.amazonaws.com/with-ecr-deployme
 docker push {account_id}.dkr.ecr.{region}.amazonaws.com/with-ecr-deployment:production
 ```
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.82.2 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.82.2 |
 | <a name="provider_null"></a> [null](#provider\_null) | >= 3.2 |
 
 ## Modules
@@ -42,6 +42,7 @@ docker push {account_id}.dkr.ecr.{region}.amazonaws.com/with-ecr-deployment:prod
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_deployment"></a> [deployment](#module\_deployment) | ../../../modules/deployment | n/a |
+| <a name="module_fixtures"></a> [fixtures](#module\_fixtures) | ../../fixtures | n/a |
 | <a name="module_lambda"></a> [lambda](#module\_lambda) | ../../../ | n/a |
 
 ## Resources
@@ -61,4 +62,4 @@ docker push {account_id}.dkr.ecr.{region}.amazonaws.com/with-ecr-deployment:prod
 ## Outputs
 
 No outputs.
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->

--- a/examples/deployment/container-image/main.tf
+++ b/examples/deployment/container-image/main.tf
@@ -1,6 +1,10 @@
+module "fixtures" {
+  source = "../../fixtures"
+}
+
 locals {
   environment   = "production"
-  function_name = "ecr-deployment"
+  function_name = module.fixtures.output_function_name
 }
 
 module "lambda" {

--- a/examples/deployment/container-image/versions.tf
+++ b/examples/deployment/container-image/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32"
+      version = ">= 5.82.2"
     }
     null = {
       source  = "hashicorp/null"

--- a/examples/deployment/s3/README.md
+++ b/examples/deployment/s3/README.md
@@ -19,26 +19,26 @@ Upload a new `zip` package to S3 to start the deployment pipeline:
 aws s3api put-object --bucket example-ci-{account_id}-{region} --key s3-deployment/package/lambda.zip --body lambda.zip
 ```
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.82.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.82.2 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_deployment"></a> [deployment](#module\_deployment) | ../../../modules/deployment | n/a |
-| <a name="module_function"></a> [function](#module\_function) | ../../fixtures | n/a |
+| <a name="module_fixtures"></a> [fixtures](#module\_fixtures) | ../../fixtures | n/a |
 | <a name="module_lambda"></a> [lambda](#module\_lambda) | ../../../ | n/a |
 
 ## Resources
@@ -63,4 +63,4 @@ aws s3api put-object --bucket example-ci-{account_id}-{region} --key s3-deployme
 ## Outputs
 
 No outputs.
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->

--- a/examples/deployment/s3/main.tf
+++ b/examples/deployment/s3/main.tf
@@ -1,13 +1,13 @@
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 
-module "function" {
+module "fixtures" {
   source = "../../fixtures"
 }
 
 locals {
   environment   = "production"
-  function_name = "s3-deployment"
+  function_name = module.fixtures.output_function_name
   s3_key        = "${local.function_name}/package/lambda.zip"
 }
 
@@ -18,7 +18,7 @@ module "lambda" {
   handler                          = "index.handler"
   ignore_external_function_updates = true
   publish                          = true
-  runtime                          = "nodejs20.x"
+  runtime                          = "nodejs22.x"
   s3_bucket                        = aws_s3_bucket.source.bucket
   s3_key                           = local.s3_key
   s3_object_version                = aws_s3_object.initial.version_id
@@ -86,8 +86,8 @@ resource "aws_s3_bucket_public_access_block" "source" {
 resource "aws_s3_object" "initial" {
   bucket = aws_s3_bucket.source.bucket
   key    = local.s3_key
-  source = module.function.output_path
-  etag   = module.function.output_md5
+  source = module.fixtures.output_path
+  etag   = module.fixtures.output_md5
 
   lifecycle {
     ignore_changes = [etag]

--- a/examples/deployment/s3/versions.tf
+++ b/examples/deployment/s3/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32"
+      version = ">= 5.82.2"
     }
   }
 }

--- a/examples/fixtures/main.tf
+++ b/examples/fixtures/main.tf
@@ -4,3 +4,7 @@ data "archive_file" "lambda" {
   source_file      = "${path.module}/context/index.js"
   type             = "zip"
 }
+
+resource "random_pet" "this" {
+  length = 2
+}

--- a/examples/fixtures/outputs.tf
+++ b/examples/fixtures/outputs.tf
@@ -9,3 +9,7 @@ output "output_base64sha256" {
 output "output_md5" {
   value = data.archive_file.lambda.output_md5
 }
+
+output "output_function_name" {
+  value = random_pet.this.id
+}

--- a/examples/fixtures/versions.tf
+++ b/examples/fixtures/versions.tf
@@ -6,5 +6,9 @@ terraform {
       source  = "hashicorp/archive"
       version = ">= 2.2"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.5"
+    }
   }
 }

--- a/examples/with-cloudwatch-event-rules/README.md
+++ b/examples/with-cloudwatch-event-rules/README.md
@@ -13,19 +13,19 @@ $ terraform apply
 
 Note that this example may create resources which cost money. Run `terraform destroy` to destroy those resources.
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.82.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.82.2 |
 
 ## Modules
 
@@ -49,4 +49,4 @@ Note that this example may create resources which cost money. Run `terraform des
 ## Outputs
 
 No outputs.
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->

--- a/examples/with-cloudwatch-event-rules/main.tf
+++ b/examples/with-cloudwatch-event-rules/main.tf
@@ -14,7 +14,7 @@ module "lambda" {
   filename         = module.source.output_path
   function_name    = "example-with-cloudwatch-events"
   handler          = "index.handler"
-  runtime          = "nodejs20.x"
+  runtime          = "nodejs22.x"
   source_code_hash = module.source.output_base64sha256
 
   cloudwatch_event_rules = {

--- a/examples/with-cloudwatch-event-rules/versions.tf
+++ b/examples/with-cloudwatch-event-rules/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32"
+      version = ">= 5.82.2"
     }
   }
 }

--- a/examples/with-cloudwatch-logs-subscription/README.md
+++ b/examples/with-cloudwatch-logs-subscription/README.md
@@ -12,13 +12,13 @@ terraform apply
 
 Note that this example may create resources which cost money. Run `terraform destroy` to destroy those resources.
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.82.2 |
 
 ## Providers
 
@@ -51,4 +51,4 @@ No resources.
 | <a name="output_cloudwatch_log_group_name"></a> [cloudwatch\_log\_group\_name](#output\_cloudwatch\_log\_group\_name) | The name of the CloudWatch log group used by your Lambda function. |
 | <a name="output_function_name"></a> [function\_name](#output\_function\_name) | The unique name of your Lambda Function. |
 | <a name="output_role_name"></a> [role\_name](#output\_role\_name) | The name of the IAM role attached to the Lambda Function. |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->

--- a/examples/with-cloudwatch-logs-subscription/main.tf
+++ b/examples/with-cloudwatch-logs-subscription/main.tf
@@ -10,7 +10,7 @@ module "lambda" {
   filename                          = module.source.output_path
   function_name                     = "example-without-cloudwatch-logs-subscription"
   handler                           = "index.handler"
-  runtime                           = "nodejs20.x"
+  runtime                           = "nodejs22.x"
   source_code_hash                  = module.source.output_base64sha256
 
   cloudwatch_log_subscription_filters = {
@@ -32,7 +32,7 @@ module "destination_1" {
   filename                          = module.source.output_path
   function_name                     = "cloudwatch-logs-subscription-destination-1"
   handler                           = "index.handler"
-  runtime                           = "nodejs20.x"
+  runtime                           = "nodejs22.x"
   source_code_hash                  = module.source.output_base64sha256
 }
 
@@ -43,6 +43,6 @@ module "destination_2" {
   filename                          = module.source.output_path
   function_name                     = "cloudwatch-logs-subscription-destination-2"
   handler                           = "index.handler"
-  runtime                           = "nodejs20.x"
+  runtime                           = "nodejs22.x"
   source_code_hash                  = module.source.output_base64sha256
 }

--- a/examples/with-cloudwatch-logs-subscription/versions.tf
+++ b/examples/with-cloudwatch-logs-subscription/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32"
+      version = ">= 5.82.2"
     }
   }
 }

--- a/examples/with-event-source-mappings/dynamodb-with-alias/README.md
+++ b/examples/with-event-source-mappings/dynamodb-with-alias/README.md
@@ -13,26 +13,27 @@ $ terraform apply
 
 Note that this example may create resources which cost money. Run `terraform destroy` to destroy those resources.
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
 | <a name="requirement_archive"></a> [archive](#requirement\_archive) | >= 2.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.82.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_archive"></a> [archive](#provider\_archive) | >= 2.2 |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.82.2 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
+| <a name="module_fixtures"></a> [fixtures](#module\_fixtures) | ../../fixtures | n/a |
 | <a name="module_lambda"></a> [lambda](#module\_lambda) | ../../.. | n/a |
 
 ## Resources
@@ -60,4 +61,4 @@ Note that this example may create resources which cost money. Run `terraform des
 | <a name="output_event_source_arns"></a> [event\_source\_arns](#output\_event\_source\_arns) | The Amazon Resource Names (ARNs) identifying the event sources. |
 | <a name="output_function_name"></a> [function\_name](#output\_function\_name) | The unique name of your Lambda Function. |
 | <a name="output_role_name"></a> [role\_name](#output\_role\_name) | The name of the IAM role attached to the Lambda Function. |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->

--- a/examples/with-event-source-mappings/dynamodb-with-alias/main.tf
+++ b/examples/with-event-source-mappings/dynamodb-with-alias/main.tf
@@ -1,3 +1,7 @@
+module "fixtures" {
+  source = "../../fixtures"
+}
+
 resource "aws_dynamodb_table" "table_1" {
   name             = "example-dynamodb-table-1"
   hash_key         = "UserId"
@@ -55,9 +59,9 @@ module "lambda" {
 
   description      = "Example usage for an AWS Lambda with a DynamoDb event source mapping"
   filename         = data.archive_file.dynamodb_handler.output_path
-  function_name    = "example-with-dynamodb-event-source-mapping"
+  function_name    = module.fixtures.output_function_name
   handler          = "index.handler"
-  runtime          = "nodejs20.x"
+  runtime          = "nodejs22.x"
   source_code_hash = data.archive_file.dynamodb_handler.output_base64sha256
 
   event_source_mappings = {

--- a/examples/with-event-source-mappings/dynamodb-with-alias/versions.tf
+++ b/examples/with-event-source-mappings/dynamodb-with-alias/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32"
+      version = ">= 5.82.2"
     }
     archive = {
       source  = "hashicorp/archive"

--- a/examples/with-event-source-mappings/kinesis/README.md
+++ b/examples/with-event-source-mappings/kinesis/README.md
@@ -13,26 +13,27 @@ $ terraform apply
 
 Note that this example may create resources which cost money. Run `terraform destroy` to destroy those resources.
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
 | <a name="requirement_archive"></a> [archive](#requirement\_archive) | >= 2.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.82.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_archive"></a> [archive](#provider\_archive) | >= 2.2 |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.82.2 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
+| <a name="module_fixtures"></a> [fixtures](#module\_fixtures) | ../../fixtures | n/a |
 | <a name="module_lambda"></a> [lambda](#module\_lambda) | ../../.. | n/a |
 
 ## Resources
@@ -58,4 +59,4 @@ Note that this example may create resources which cost money. Run `terraform des
 | <a name="output_event_source_arns"></a> [event\_source\_arns](#output\_event\_source\_arns) | The Amazon Resource Names (ARNs) identifying the event sources. |
 | <a name="output_function_name"></a> [function\_name](#output\_function\_name) | The unique name of your Lambda Function. |
 | <a name="output_role_name"></a> [role\_name](#output\_role\_name) | The name of the IAM role attached to the Lambda Function. |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->

--- a/examples/with-event-source-mappings/kinesis/main.tf
+++ b/examples/with-event-source-mappings/kinesis/main.tf
@@ -1,3 +1,7 @@
+module "fixtures" {
+  source = "../../fixtures"
+}
+
 resource "aws_kinesis_stream" "stream_1" {
   encryption_type = "KMS"
   kms_key_id      = "alias/aws/kinesis"
@@ -27,9 +31,9 @@ module "lambda" {
 
   description      = "Example usage for an AWS Lambda with a Kinesis event source mapping"
   filename         = data.archive_file.kinesis_handler.output_path
-  function_name    = "example-with-kinesis-event-source-mapping"
+  function_name    = module.fixtures.output_function_name
   handler          = "index.handler"
-  runtime          = "nodejs20.x"
+  runtime          = "nodejs22.x"
   source_code_hash = data.archive_file.kinesis_handler.output_base64sha256
 
   event_source_mappings = {

--- a/examples/with-event-source-mappings/kinesis/versions.tf
+++ b/examples/with-event-source-mappings/kinesis/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32"
+      version = ">= 5.82.2"
     }
     archive = {
       source  = "hashicorp/archive"

--- a/examples/with-event-source-mappings/sqs/README.md
+++ b/examples/with-event-source-mappings/sqs/README.md
@@ -13,26 +13,27 @@ $ terraform apply
 
 Note that this example may create resources which cost money. Run `terraform destroy` to destroy those resources.
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
 | <a name="requirement_archive"></a> [archive](#requirement\_archive) | >= 2.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.82.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_archive"></a> [archive](#provider\_archive) | >= 2.2 |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.82.2 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
+| <a name="module_fixtures"></a> [fixtures](#module\_fixtures) | ../../fixtures | n/a |
 | <a name="module_lambda"></a> [lambda](#module\_lambda) | ../../.. | n/a |
 
 ## Resources
@@ -57,4 +58,4 @@ Note that this example may create resources which cost money. Run `terraform des
 | <a name="output_event_source_arns"></a> [event\_source\_arns](#output\_event\_source\_arns) | The Amazon Resource Names (ARNs) identifying the event sources. |
 | <a name="output_function_name"></a> [function\_name](#output\_function\_name) | The unique name of your Lambda Function. |
 | <a name="output_role_name"></a> [role\_name](#output\_role\_name) | The name of the IAM role attached to the Lambda Function. |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->

--- a/examples/with-event-source-mappings/sqs/main.tf
+++ b/examples/with-event-source-mappings/sqs/main.tf
@@ -1,3 +1,7 @@
+module "fixtures" {
+  source = "../../fixtures"
+}
+
 #trivy:ignore:AVD-AWS-0135
 resource "aws_sqs_queue" "queue_1" {
   kms_master_key_id = "alias/aws/sqs"
@@ -25,9 +29,9 @@ module "lambda" {
 
   description      = "Example usage for an AWS Lambda with a SQS event source mapping"
   filename         = data.archive_file.sqs_handler.output_path
-  function_name    = "example-with-sqs-event-source-mapping"
+  function_name    = module.fixtures.output_function_name
   handler          = "index.handler"
-  runtime          = "nodejs20.x"
+  runtime          = "nodejs22.x"
   source_code_hash = data.archive_file.sqs_handler.output_base64sha256
 
   event_source_mappings = {

--- a/examples/with-event-source-mappings/sqs/versions.tf
+++ b/examples/with-event-source-mappings/sqs/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32"
+      version = ">= 5.82.2"
     }
     archive = {
       source  = "hashicorp/archive"

--- a/examples/with-sns-subscriptions/README.md
+++ b/examples/with-sns-subscriptions/README.md
@@ -20,26 +20,27 @@ $ func new example-with-sns -e sns
 $ cd example-with-sns && make init package plan
 ```
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
 | <a name="requirement_archive"></a> [archive](#requirement\_archive) | >= 2.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.82.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_archive"></a> [archive](#provider\_archive) | >= 2.2 |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.82.2 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
+| <a name="module_fixtures"></a> [fixtures](#module\_fixtures) | ../fixtures | n/a |
 | <a name="module_lambda"></a> [lambda](#module\_lambda) | ../../ | n/a |
 
 ## Resources
@@ -67,4 +68,4 @@ $ cd example-with-sns && make init package plan
 ## Outputs
 
 No outputs.
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->

--- a/examples/with-sns-subscriptions/main.tf
+++ b/examples/with-sns-subscriptions/main.tf
@@ -1,5 +1,9 @@
 data "aws_caller_identity" "current" {}
 
+module "fixtures" {
+  source = "../fixtures"
+}
+
 // see https://docs.aws.amazon.com/sns/latest/dg/sns-dead-letter-queues.html
 // for using encrypted SNS topics with SQS DLQs
 resource "aws_kms_key" "kms_key_sqs_sns" {
@@ -107,9 +111,9 @@ module "lambda" {
   source           = "../../"
   description      = "Example usage for an AWS Lambda with a SNS event trigger."
   filename         = data.archive_file.sns_handler.output_path
-  function_name    = "example-with-sns-event"
+  function_name    = module.fixtures.output_function_name
   handler          = "index.handler"
-  runtime          = "nodejs20.x"
+  runtime          = "nodejs22.x"
   source_code_hash = data.archive_file.sns_handler.output_base64sha256
 
   sns_subscriptions = {

--- a/examples/with-sns-subscriptions/versions.tf
+++ b/examples/with-sns-subscriptions/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32"
+      version = ">= 5.82.2"
     }
     archive = {
       source  = "hashicorp/archive"

--- a/examples/with-vpc/README.md
+++ b/examples/with-vpc/README.md
@@ -11,35 +11,32 @@ terraform plan
 
 Note that this example may create resources which cost money. Run `terraform destroy` to destroy those resources.
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.5 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.82.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32 |
-| <a name="provider_random"></a> [random](#provider\_random) | >= 3.5 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.82.2 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
+| <a name="module_fixtures"></a> [fixtures](#module\_fixtures) | ../fixtures | n/a |
 | <a name="module_lambda"></a> [lambda](#module\_lambda) | ../../ | n/a |
-| <a name="module_source"></a> [source](#module\_source) | ../fixtures | n/a |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 5.0 |
 
 ## Resources
 
 | Name | Type |
 |------|------|
-| [random_pet.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |
 | [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
 
 ## Inputs
@@ -51,4 +48,4 @@ Note that this example may create resources which cost money. Run `terraform des
 ## Outputs
 
 No outputs.
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->

--- a/examples/with-vpc/versions.tf
+++ b/examples/with-vpc/versions.tf
@@ -4,11 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32"
-    }
-    random = {
-      source  = "hashicorp/random"
-      version = ">= 3.5"
+      version = ">= 5.82.2"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -11,8 +11,7 @@ locals {
 }
 
 resource "aws_lambda_function" "lambda" {
-  count      = var.ignore_external_function_updates ? 0 : 1
-  depends_on = [aws_cloudwatch_log_group.lambda]
+  count = var.ignore_external_function_updates ? 0 : 1
 
   architectures                      = var.architectures
   description                        = var.description
@@ -79,6 +78,10 @@ resource "aws_lambda_function" "lambda" {
       apply_on = "PublishedVersions"
     }
   }
+
+  // create the CloudWatch log group first so it's no create automatically
+  // by AWS Lambda
+  depends_on = [aws_cloudwatch_log_group.lambda]
 }
 
 // Copy of the original Lambda resource plus lifecycle configuration ignoring
@@ -87,8 +90,7 @@ resource "aws_lambda_function" "lambda" {
 // We need this copy workaround, since lifecycle configuration must be static,
 // see https://github.com/hashicorp/terraform/issues/24188.
 resource "aws_lambda_function" "lambda_external_lifecycle" {
-  count      = var.ignore_external_function_updates ? 1 : 0
-  depends_on = [aws_cloudwatch_log_group.lambda]
+  count = var.ignore_external_function_updates ? 1 : 0
 
   architectures                      = var.architectures
   description                        = var.description
@@ -155,6 +157,10 @@ resource "aws_lambda_function" "lambda_external_lifecycle" {
       apply_on = "PublishedVersions"
     }
   }
+
+  // create the CloudWatch log group first so it's no create automatically
+  // by AWS Lambda
+  depends_on = [aws_cloudwatch_log_group.lambda]
 
   lifecycle {
     ignore_changes = [image_uri, last_modified, qualified_arn, qualified_invoke_arn, s3_object_version, version]

--- a/modules/deployment/README.md
+++ b/modules/deployment/README.md
@@ -127,7 +127,7 @@ module "lambda" {
   handler                          = "index.handler"
   ignore_external_function_updates = true
   publish                          = true
-  runtime                          = "nodejs20.x"
+  runtime                          = "nodejs22.x"
   s3_bucket                        = aws_s3_object.source.bucket
   s3_key                           = local.s3_key
   s3_object_version                = aws_s3_object.source.version_id
@@ -354,19 +354,19 @@ module "deployment" {
 - [container-image (ECR)](../../examples/deployment/container-image)
 - [zipped package (S3)](../../examples/deployment/s3)
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.82.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.82.2 |
 
 ## Modules
 
@@ -420,13 +420,13 @@ No modules.
 | <a name="input_codedeploy_deployment_group_auto_rollback_configuration_events"></a> [codedeploy\_deployment\_group\_auto\_rollback\_configuration\_events](#input\_codedeploy\_deployment\_group\_auto\_rollback\_configuration\_events) | The event type or types that trigger a rollback. Supported types are `DEPLOYMENT_FAILURE` and `DEPLOYMENT_STOP_ON_ALARM` | `list(string)` | `[]` | no |
 | <a name="input_codepipeline_artifact_store_bucket"></a> [codepipeline\_artifact\_store\_bucket](#input\_codepipeline\_artifact\_store\_bucket) | Name of an existing S3 bucket used by AWS CodePipeline to store pipeline artifacts. Use the same bucket name as in `s3_bucket` to store deployment packages and pipeline artifacts in one bucket for `package_type=Zip` functions. If empty, a dedicated S3 bucket for your Lambda function will be created. | `string` | `""` | no |
 | <a name="input_codepipeline_artifact_store_encryption_key_id"></a> [codepipeline\_artifact\_store\_encryption\_key\_id](#input\_codepipeline\_artifact\_store\_encryption\_key\_id) | The KMS key ARN or ID of a key block AWS CodePipeline uses to encrypt the data in the artifact store, such as an AWS Key Management Service (AWS KMS) key. If you don't specify a key, AWS CodePipeline uses the default key for Amazon Simple Storage Service (Amazon S3). | `string` | `""` | no |
-| <a name="input_codepipeline_post_deployment_stages"></a> [codepipeline\_post\_deployment\_stages](#input\_codepipeline\_post\_deployment\_stages) | A map of post deployment stages to execute after the Lambda function has been deployed. The following stages are supported: `CodeBuild`, `CodeDeploy`, `CodePipeline`, `CodeStarNotifications`. | <pre>list(object({<br>    name = string<br>    actions = list(object({<br>      name             = string<br>      category         = string<br>      owner            = string<br>      provider         = string<br>      version          = string<br>      input_artifacts  = optional(list(any))<br>      output_artifacts = optional(list(any))<br>      configuration    = optional(map(string))<br>    }))<br>  }))</pre> | `[]` | no |
+| <a name="input_codepipeline_post_deployment_stages"></a> [codepipeline\_post\_deployment\_stages](#input\_codepipeline\_post\_deployment\_stages) | A map of post deployment stages to execute after the Lambda function has been deployed. The following stages are supported: `CodeBuild`, `CodeDeploy`, `CodePipeline`, `CodeStarNotifications`. | <pre>list(object({<br/>    name = string<br/>    actions = list(object({<br/>      name             = string<br/>      category         = string<br/>      owner            = string<br/>      provider         = string<br/>      version          = string<br/>      input_artifacts  = optional(list(any))<br/>      output_artifacts = optional(list(any))<br/>      configuration    = optional(map(string))<br/>    }))<br/>  }))</pre> | `[]` | no |
 | <a name="input_codepipeline_role_arn"></a> [codepipeline\_role\_arn](#input\_codepipeline\_role\_arn) | ARN of an existing IAM role for CodePipeline execution. If empty, a dedicated role for your Lambda function with minimal required permissions will be created. | `string` | `""` | no |
 | <a name="input_codepipeline_type"></a> [codepipeline\_type](#input\_codepipeline\_type) | Type of the CodePipeline. Possible values are: `V1` and `V2`. | `string` | `"V1"` | no |
-| <a name="input_codepipeline_variables"></a> [codepipeline\_variables](#input\_codepipeline\_variables) | CodePipeline variables. Valid only when `codepipeline_type` is `V2`. | <pre>list(object({<br>    name          = string<br>    default_value = optional(string)<br>    description   = optional(string)<br>  }))</pre> | `[]` | no |
+| <a name="input_codepipeline_variables"></a> [codepipeline\_variables](#input\_codepipeline\_variables) | CodePipeline variables. Valid only when `codepipeline_type` is `V2`. | <pre>list(object({<br/>    name          = string<br/>    default_value = optional(string)<br/>    description   = optional(string)<br/>  }))</pre> | `[]` | no |
 | <a name="input_codestar_notifications_detail_type"></a> [codestar\_notifications\_detail\_type](#input\_codestar\_notifications\_detail\_type) | The level of detail to include in the notifications for this resource. Possible values are BASIC and FULL. | `string` | `"BASIC"` | no |
 | <a name="input_codestar_notifications_enabled"></a> [codestar\_notifications\_enabled](#input\_codestar\_notifications\_enabled) | Enable CodeStar notifications for your pipeline. | `bool` | `true` | no |
-| <a name="input_codestar_notifications_event_type_ids"></a> [codestar\_notifications\_event\_type\_ids](#input\_codestar\_notifications\_event\_type\_ids) | A list of event types associated with this notification rule. For list of allowed events see https://docs.aws.amazon.com/dtconsole/latest/userguide/concepts.html#events-ref-pipeline. | `list(string)` | <pre>[<br>  "codepipeline-pipeline-pipeline-execution-succeeded",<br>  "codepipeline-pipeline-pipeline-execution-failed"<br>]</pre> | no |
+| <a name="input_codestar_notifications_event_type_ids"></a> [codestar\_notifications\_event\_type\_ids](#input\_codestar\_notifications\_event\_type\_ids) | A list of event types associated with this notification rule. For list of allowed events see https://docs.aws.amazon.com/dtconsole/latest/userguide/concepts.html#events-ref-pipeline. | `list(string)` | <pre>[<br/>  "codepipeline-pipeline-pipeline-execution-succeeded",<br/>  "codepipeline-pipeline-pipeline-execution-failed"<br/>]</pre> | no |
 | <a name="input_codestar_notifications_target_arn"></a> [codestar\_notifications\_target\_arn](#input\_codestar\_notifications\_target\_arn) | Use an existing ARN for a notification rule target (for example, a SNS Topic ARN). Otherwise a separate sns topic for this service will be created. | `string` | `""` | no |
 | <a name="input_deployment_config_name"></a> [deployment\_config\_name](#input\_deployment\_config\_name) | The name of the deployment config used in the CodeDeploy deployment group, see https://docs.aws.amazon.com/codedeploy/latest/userguide/deployment-configurations.html for all available default configurations or provide a custom one. | `string` | `"CodeDeployDefault.LambdaAllAtOnce"` | no |
 | <a name="input_ecr_image_tag"></a> [ecr\_image\_tag](#input\_ecr\_image\_tag) | The container tag used for ECR/container based deployments. | `string` | `"latest"` | no |
@@ -451,4 +451,4 @@ No modules.
 | <a name="output_codepipeline_artifact_storage_arn"></a> [codepipeline\_artifact\_storage\_arn](#output\_codepipeline\_artifact\_storage\_arn) | The Amazon Resource Name (ARN) of the CodePipeline artifact store. |
 | <a name="output_codepipeline_id"></a> [codepipeline\_id](#output\_codepipeline\_id) | The ID of the CodePipeline. |
 | <a name="output_codepipeline_role_name"></a> [codepipeline\_role\_name](#output\_codepipeline\_role\_name) | The name of the IAM role used for the CodePipeline. |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->

--- a/modules/deployment/versions.tf
+++ b/modules/deployment/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32"
+      version = ">= 5.82.2"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32"
+      version = ">= 5.82.2"
     }
   }
 }


### PR DESCRIPTION
This pull request refactors IAM configuration to use [inline policies](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_managed-vs-inline.html#inline-policies) instead of customer managed ones for better alignment with AWS best practices and to simplify policy attachments:

> An inline policy is a policy created for a single IAM identity (a user, user group, or role). Inline policies maintain a strict one-to-one relationship between a policy and an identity. 

### Provider Upgrades:
* Use latest `nodejs22.x` runtime in examples
* Updated the AWS provider version constraint to `>= 5.82.2` across multiple files, ensuring compatibility with the latest features and bug fixes. (`Makefile`, `README.md`, `examples/complete/versions.tf`, `examples/container-image/README.md`, `examples/container-image/main.tf`) [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L107-R107) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L342-R354) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L368-R374) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R383-R385) [[5]](diffhunk://#diff-31806d683b0054c3a6d65a1e93add86f6cded9cf1f674672be315de14e74badaL15-R35)

### Makefile Enhancements:
* Added support for `darwin_arm64` platform in the `terraform providers lock` command to enhance compatibility with Apple Silicon devices. (`Makefile`)

### Module Adjustments:
* Updated example modules to use `fixtures` module instead of `source` module for consistency and clarity. (`examples/complete/main.tf`, `examples/container-image/main.tf`) [[1]](diffhunk://#diff-07f337e38ed1996f30ee4f04357ab23318c254cb606aaf4745d564cbd546722dL3-R28) [[2]](diffhunk://#diff-b71ad04f644acd7192bbc30fcb3f747a785983233f38a333c93c9f4541f7989aR1-R7)