### PR TITLE
feat(deployment): enhanced region support

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -1,0 +1,5 @@
+data "aws_caller_identity" "current" {}
+data "aws_partition" "current" {}
+data "aws_region" "current" {
+  region = var.region
+}

--- a/examples/deployment/complete/codepipeline_step.tf
+++ b/examples/deployment/complete/codepipeline_step.tf
@@ -3,11 +3,15 @@ locals {
 }
 
 resource "aws_cloudwatch_log_group" "custom_step" {
+  region = var.region
+
   name              = "/aws/codebuild/${local.codebuild_name}"
   retention_in_days = 1
 }
 
 resource "aws_codebuild_project" "custom_step" {
+  region = var.region
+
   name         = local.codebuild_name
   service_role = aws_iam_role.custom_codepipeline_step.arn
 

--- a/examples/deployment/complete/codepipeline_step.tf
+++ b/examples/deployment/complete/codepipeline_step.tf
@@ -3,14 +3,14 @@ locals {
 }
 
 resource "aws_cloudwatch_log_group" "custom_step" {
-  region = var.region
+  region = local.region
 
   name              = "/aws/codebuild/${local.codebuild_name}"
   retention_in_days = 1
 }
 
 resource "aws_codebuild_project" "custom_step" {
-  region = var.region
+  region = local.region
 
   name         = local.codebuild_name
   service_role = aws_iam_role.custom_codepipeline_step.arn

--- a/examples/deployment/complete/data.tf
+++ b/examples/deployment/complete/data.tf
@@ -1,0 +1,5 @@
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {
+  region = local.region
+}
+

--- a/examples/deployment/complete/main.tf
+++ b/examples/deployment/complete/main.tf
@@ -27,7 +27,7 @@ module "lambda" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "error_rate" {
-  region = var.region
+  region = local.region
 
   alarm_description   = "${module.lambda.function_name} has a high error rate"
   alarm_name          = "${module.lambda.function_name}-error-rate"

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,3 @@
-data "aws_region" "current" {}
-data "aws_caller_identity" "current" {}
-data "aws_partition" "current" {}
-
 locals {
   function_arn = "arn:${data.aws_partition.current.partition}:lambda:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:function:${var.function_name}"
   handler      = var.package_type != "Zip" ? null : var.handler

--- a/modules/deployment/README.md
+++ b/modules/deployment/README.md
@@ -455,6 +455,7 @@ No modules.
 | <a name="input_ecr_image_tag"></a> [ecr\_image\_tag](#input\_ecr\_image\_tag) | The container tag used for ECR/container based deployments. | `string` | `"latest"` | no |
 | <a name="input_ecr_repository_name"></a> [ecr\_repository\_name](#input\_ecr\_repository\_name) | Name of the ECR repository source used for ECR/container based deployments, required for `package_type=Image`. | `string` | `""` | no |
 | <a name="input_function_name"></a> [function\_name](#input\_function\_name) | The name of your Lambda Function to deploy. | `string` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | Alternative region used in all region-aware resources. If not set, the provider's region will be used. | `string` | `null` | no |
 | <a name="input_s3_bucket"></a> [s3\_bucket](#input\_s3\_bucket) | Name of the bucket used for S3 based deployments, required for `package_type=Zip`. Make sure to enable S3 bucket notifications for this bucket for continuous deployment of your Lambda function, see https://docs.aws.amazon.com/AmazonS3/latest/userguide/EventBridge.html. | `string` | `""` | no |
 | <a name="input_s3_key"></a> [s3\_key](#input\_s3\_key) | Object key used for S3 based deployments, required for `package_type=Zip`. | `string` | `""` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to all resources supporting tags. | `map(string)` | `{}` | no |

--- a/modules/deployment/codebuild.tf
+++ b/modules/deployment/codebuild.tf
@@ -1,4 +1,5 @@
 resource "aws_cloudwatch_log_group" "this" {
+  region = var.region
 
   name              = "/aws/codebuild/${var.function_name}"
   retention_in_days = var.codebuild_cloudwatch_logs_retention_in_days
@@ -6,6 +7,8 @@ resource "aws_cloudwatch_log_group" "this" {
 }
 
 resource "aws_codebuild_project" "this" {
+  region = var.region
+
   name         = var.function_name
   service_role = var.codebuild_role_arn == "" ? aws_iam_role.codebuild_role[0].arn : var.codebuild_role_arn
   tags         = var.tags

--- a/modules/deployment/codedeploy.tf
+++ b/modules/deployment/codedeploy.tf
@@ -1,9 +1,13 @@
 resource "aws_codedeploy_app" "this" {
+  region = var.region
+
   name             = var.function_name
   compute_platform = "Lambda"
 }
 
 resource "aws_codedeploy_deployment_group" "this" {
+  region = var.region
+
   app_name               = var.function_name
   deployment_config_name = var.deployment_config_name
   deployment_group_name  = var.alias_name

--- a/modules/deployment/data.tf
+++ b/modules/deployment/data.tf
@@ -1,0 +1,5 @@
+data "aws_caller_identity" "current" {}
+data "aws_partition" "current" {}
+data "aws_region" "current" {
+  region = var.region
+}

--- a/modules/deployment/notification.tf
+++ b/modules/deployment/notification.tf
@@ -16,6 +16,8 @@ data "aws_iam_policy_document" "sns_codestar_policy" {
 resource "aws_codestarnotifications_notification_rule" "notification" {
   count = var.codestar_notifications_enabled ? 1 : 0
 
+  region = var.region
+
   detail_type    = var.codestar_notifications_detail_type
   event_type_ids = var.codestar_notifications_event_type_ids
   name           = "${local.iam_role_prefix}-notifications-${data.aws_region.current.region}"
@@ -31,12 +33,16 @@ resource "aws_codestarnotifications_notification_rule" "notification" {
 resource "aws_sns_topic" "notifications" {
   count = var.codestar_notifications_enabled && var.codestar_notifications_target_arn == "" ? 1 : 0
 
+  region = var.region
+
   name = "${var.function_name}-notifications"
   tags = var.tags
 }
 
 resource "aws_sns_topic_policy" "notifications" {
   count = var.codestar_notifications_enabled && var.codestar_notifications_target_arn == "" ? 1 : 0
+
+  region = var.region
 
   arn    = aws_sns_topic.notifications[count.index].arn
   policy = data.aws_iam_policy_document.sns_codestar_policy[count.index].json

--- a/modules/deployment/trigger_ecr.tf
+++ b/modules/deployment/trigger_ecr.tf
@@ -1,6 +1,8 @@
 resource "aws_cloudwatch_event_rule" "this" {
   count = var.ecr_repository_name != "" ? 1 : 0
 
+  region = var.region
+
   name        = "${var.function_name}-ecr-trigger"
   description = "Amazon CloudWatch Events rule to automatically start the pipeline when a change occurs in the Elastic Container Registry."
   tags        = var.tags
@@ -33,6 +35,8 @@ PATTERN
 
 resource "aws_cloudwatch_event_target" "trigger" {
   count = var.ecr_repository_name != "" ? 1 : 0
+
+  region = var.region
 
   arn       = aws_codepipeline.this.arn
   role_arn  = aws_iam_role.trigger.arn

--- a/modules/deployment/trigger_s3.tf
+++ b/modules/deployment/trigger_s3.tf
@@ -1,6 +1,8 @@
 resource "aws_cloudwatch_event_rule" "s3_trigger" {
   count = var.s3_bucket != "" ? 1 : 0
 
+  region = var.region
+
   name        = "${local.iam_role_prefix}-s3-trigger"
   description = "Amazon CloudWatch Events rule to automatically start the pipeline when a change occurs in the Amazon S3 object key or S3 folder."
   tags        = var.tags
@@ -23,6 +25,8 @@ PATTERN
 
 resource "aws_cloudwatch_event_target" "s3_trigger" {
   count = var.s3_bucket != "" ? 1 : 0
+
+  region = var.region
 
   arn       = aws_codepipeline.this.arn
   role_arn  = aws_iam_role.trigger.arn

--- a/modules/deployment/variables.tf
+++ b/modules/deployment/variables.tf
@@ -186,6 +186,12 @@ variable "ecr_repository_name" {
   type        = string
 }
 
+variable "region" {
+  description = "Alternative region used in all region-aware resources. If not set, the provider's region will be used."
+  default     = null
+  type        = string
+}
+
 variable "s3_bucket" {
   description = "Name of the bucket used for S3 based deployments, required for `package_type=Zip`. Make sure to enable S3 bucket notifications for this bucket for continuous deployment of your Lambda function, see https://docs.aws.amazon.com/AmazonS3/latest/userguide/EventBridge.html."
   default     = ""


### PR DESCRIPTION
This pull request enhances region support across the deployment module by introducing a configurable region variable that allows users to specify an alternative region for all region-aware AWS resources. If not set, the provider's default region will be used.

- Adds a new `region` variable to the deployment module and root module with proper documentation
- Refactors data sources by moving them to dedicated `data.tf` files for better organization
- Updates all AWS resources to use the configurable region parameter instead of relying solely on provider defaults
- updated example to showcase feature