### PR TITLE
feat: event source mapping metrics support

### DIFF
--- a/event_source_mappings.tf
+++ b/event_source_mappings.tf
@@ -72,6 +72,14 @@ resource "aws_lambda_event_source_mapping" "event_source" {
     }
   }
 
+  dynamic "metrics_config" {
+    for_each = try([each.value.metrics_config], [])
+
+    content {
+      metrics = metrics_config.value.metrics
+    }
+  }
+
   dynamic "scaling_config" {
     for_each = try(each.value.scaling_config, null) != null ? [true] : []
 

--- a/examples/with-event-source-mappings/dynamodb-with-alias/main.tf
+++ b/examples/with-event-source-mappings/dynamodb-with-alias/main.tf
@@ -81,7 +81,6 @@ module "lambda" {
       // see https://docs.aws.amazon.com/lambda/latest/dg/invocation-eventsourcemapping.html
       destination_arn_on_failure = aws_sqs_queue.errors.arn
 
-
       // Lambda event filtering, see https://docs.aws.amazon.com/lambda/latest/dg/invocation-eventfiltering.html
       filter_criteria = [
         {
@@ -99,6 +98,11 @@ module "lambda" {
           })
         }
       ]
+
+      // Event source mapping metrics, see https://docs.aws.amazon.com/lambda/latest/dg/monitoring-metrics-types.html#event-source-mapping-metrics
+      metrics_config = {
+        metrics = ["EventCount"]
+      }
     }
 
     table_2 = {

--- a/examples/with-event-source-mappings/kinesis/main.tf
+++ b/examples/with-event-source-mappings/kinesis/main.tf
@@ -65,6 +65,11 @@ module "lambda" {
           })
         }
       ]
+
+      // Event source mapping metrics, see https://docs.aws.amazon.com/lambda/latest/dg/monitoring-metrics-types.html#event-source-mapping-metrics
+      metrics_config = {
+        metrics = ["EventCount"]
+      }
     }
 
     stream_2 = {

--- a/examples/with-event-source-mappings/sqs/main.tf
+++ b/examples/with-event-source-mappings/sqs/main.tf
@@ -45,10 +45,6 @@ module "lambda" {
       // optionally overwrite arguments from https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_event_source_mapping
       batch_size = 5
 
-      scaling_config = {
-        maximum_concurrency = 2
-      }
-
       // Lambda event filtering, see https://docs.aws.amazon.com/lambda/latest/dg/invocation-eventfiltering.html
       filter_criteria = [
         {
@@ -66,6 +62,15 @@ module "lambda" {
           })
         }
       ]
+
+      // Event source mapping metrics, see https://docs.aws.amazon.com/lambda/latest/dg/monitoring-metrics-types.html#event-source-mapping-metrics
+      metrics_config = {
+        metrics = ["EventCount"]
+      }
+
+      scaling_config = {
+        maximum_concurrency = 2
+      }
     }
 
     queue_2 = {


### PR DESCRIPTION
This PR adds support for event source mapping metrics, see [aws docs](https://docs.aws.amazon.com/lambda/latest/dg/monitoring-metrics-types.html#event-source-mapping-metrics) for details