### PR TITLE
feat: module for IAM role to trigger deployments from GitHub actions

### DIFF
--- a/modules/github-actions-role/README.md
+++ b/modules/github-actions-role/README.md
@@ -1,0 +1,66 @@
+# GitHub Actions OIDC mapped role to trigger deployments
+
+Terraform module to create an AWS IAM role that can be used with OpenID Connect[^1] to trigger [deployments](../deployment)
+from GitHub Actions. The role can be used with `configure-aws-credentials`[^3].
+
+# Prerequisites
+
+The GitHub identity provider must already be added to the AWS account. See the GitHub documentation[^2].
+
+# How to use
+
+Create a role like this
+
+```terraform
+module "github_role" {
+  source = "moritzzimmer/lambda/aws//modules/github-actions-role"
+
+  github_repository = "moritzzimmer/my-lambda"
+
+  # Both s3_prefixes and ecr_repositories are optional, but if neither are set the role can't do anything
+  s3_prefixes      = ["my-deploy-bucket/my-lambda"]
+  ecr_repositories = ["my-ecr-repository"]
+
+  role_name   = "my-role" # Optional, will be github-actions-my-lambda-eu-central-1 otherwise
+  github_refs = ["main", "production"] # Optional, defaults to ["main"]
+}
+```
+
+It can then be used in a GitHub Action workflow like this
+
+```yaml
+name: My Workflow
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      # Your build steps here
+
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v5
+        with:
+          role-to-assume: arn:aws:iam::$account-id:role/my-role
+          role-session-name: GitHubActions
+          aws-region: $region
+
+      # Your steps using AWS, e.g. S3 put, ECR push
+```
+
+# References
+
+[^1]: https://docs.github.com/en/actions/concepts/security/openid-connect
+[^2]: https://docs.github.com/en/actions/how-tos/secure-your-work/security-harden-deployments/oidc-in-aws#adding-the-identity-provider-to-aws
+[^3]: https://github.com/aws-actions/configure-aws-credentials

--- a/modules/github-actions-role/data.tf
+++ b/modules/github-actions-role/data.tf
@@ -1,0 +1,7 @@
+data "aws_region" "current" {}
+
+data "aws_caller_identity" "current" {}
+
+data "aws_iam_openid_connect_provider" "github" {
+  url = "https://token.actions.githubusercontent.com"
+}

--- a/modules/github-actions-role/main.tf
+++ b/modules/github-actions-role/main.tf
@@ -1,0 +1,88 @@
+resource "aws_iam_role" "github_actions" {
+  name               = var.role_name != null ? var.role_name : "github-actions-${split("/", var.github_repository)[0]}-${data.aws_region.current.region}"
+  assume_role_policy = data.aws_iam_policy_document.github_actions_assume.json
+}
+
+data "aws_iam_policy_document" "github_actions_assume" {
+  statement {
+    sid     = "GithubOIDCAccess"
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    condition {
+      test     = "StringEquals"
+      values   = [for ref in var.github_refs : "repo:${var.github_repository}:ref/refs/heads/${ref}"]
+      variable = "token.actions.githubusercontent.com:sub"
+    }
+
+    principals {
+      type        = "Federated"
+      identifiers = [data.aws_iam_openid_connect_provider.github.id]
+    }
+  }
+}
+
+resource "aws_iam_role_policy" "s3" {
+  count  = var.s3_prefixes != null ? 1 : 0
+  role   = aws_iam_role.github_actions.name
+  name   = "s3-access"
+  policy = data.aws_iam_policy_document.s3[0].json
+}
+
+data "aws_iam_policy_document" "s3" {
+  count = var.s3_prefixes != null ? 1 : 0
+  statement {
+    sid       = "BucketLevelAccess"
+    effect    = "Allow"
+    resources = [for prefix in var.s3_prefixes : "arn:aws:s3:::${split("/", prefix)[0]}"]
+    actions = [
+      "s3:ListBucket",
+      "s3:GetBucketLocation"
+    ]
+  }
+
+  statement {
+    sid       = "ObjectLevelAccess"
+    effect    = "Allow"
+    resources = [for prefix in var.s3_prefixes : "arn:aws:s3:::${prefix}/*"]
+    actions = [
+      "s3:PutObject",
+      "s3:GetObject"
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "ecr" {
+  count  = var.ecr_repositories != null ? 1 : 0
+  role   = aws_iam_role.github_actions.name
+  name   = "ecr-access"
+  policy = data.aws_iam_policy_document.ecr[0].json
+}
+
+data "aws_iam_policy_document" "ecr" {
+  count = var.ecr_repositories != null ? 1 : 0
+  statement {
+    sid       = "GetAuthToken"
+    effect    = "Allow"
+    actions   = ["ecr:GetAuthorizationToken"]
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "PutImage"
+    effect = "Allow"
+    actions = [
+      "ecr:CompleteLayerUpload",
+      "ecr:UploadLayerPart",
+      "ecr:InitiateLayerUpload",
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:PutImage",
+      "ecr:BatchGetImage",
+      "ecr:GetDownloadUrlForLayer"
+    ]
+    resources = [
+      for repo in var.ecr_repositories :
+      "arn:aws:ecr:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:repository/${repo}"
+    ]
+  }
+}

--- a/modules/github-actions-role/outputs.tf
+++ b/modules/github-actions-role/outputs.tf
@@ -1,0 +1,4 @@
+output "role_name" {
+  value       = aws_iam_role.github_actions.name
+  description = "The name of the IAM role created"
+}

--- a/modules/github-actions-role/variables.tf
+++ b/modules/github-actions-role/variables.tf
@@ -1,0 +1,37 @@
+variable "github_repository" {
+  description = "Name of the GitHub repository that will run the action, including repository owner (e.g. moritzzimmer/terraform-aws-lambda)"
+  type        = string
+  nullable    = false
+  validation {
+    condition     = length(split("/", var.github_repository)) == 2
+    error_message = "Repository must be of format $owner/$repository_name"
+  }
+}
+
+variable "github_refs" {
+  description = "Name of the refs (e.g. branches) on which the action will run."
+  type        = list(string)
+  default     = ["main"]
+  nullable    = false
+}
+
+variable "role_name" {
+  description = "Name of the IAM role to create. If not set github-actions-$github_repository-$region will be used"
+  type        = string
+  default     = null
+  nullable    = true
+}
+
+variable "s3_prefixes" {
+  description = "(Optional) S3 prefixes (bucket name + key) that the role can write/read to/from. E.g. ci-eu-central-1/foo. If not set, no S3 access will be granted."
+  type        = list(string)
+  default     = null
+  nullable    = true
+}
+
+variable "ecr_repositories" {
+  description = "(Optional) ECR repository names that the role can push to. If not set, no ECR access will be granted."
+  type        = list(string)
+  default     = null
+  nullable    = true
+}

--- a/modules/github-actions-role/versions.tf
+++ b/modules/github-actions-role/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.7"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.0"
+    }
+  }
+}


### PR DESCRIPTION
Adds a module that creates an AWS IAM role that can be used from GitHub actions with [configure-aws-credentials](https://github.com/aws-actions/configure-aws-credentials) to trigger deployments using the deployment module (by putting objects into S3 or pushing an ECR image).

---

Should I add an example or maybe even extend an existing example? E.g., in `examples/deployment/complete` the idea would be to have this:

```terraform
module "github_role" {
  source = "../../../modules/github-actions-role"

  github_repository = "moritzzimmer/terraform-aws-lambda"
  s3_prefixes       = ["${aws_s3_bucket.source.bucket}/${local.function_name}"]
}
```

and in `examples/deployment/container-image`:

```terraform
module "github_role" {
  source = "../../../modules/github-actions-role"

  github_repository = "moritzzimmer/terraform-aws-lambda"
  ecr_repositories  = [aws_ecr_repository.this.name]
}
```